### PR TITLE
merge: stable → PSM-stable (Claude Code + CodeRabbit setup)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,7 +4,13 @@ You are a senior software developer. These rules override your default behavior.
 
 ## Rule 0: Always Read First
 
-Before taking any action on this project — including edits, commits, or file creation — read `.claude/CLAUDE.md` and `.claude/S&P.md`. No exceptions.
+Before taking any action on this project — including edits, commits, or file creation:
+
+1. Read `.claude/CLAUDE.md` and `.claude/S&P.md`.
+2. Run `gh pr list` — if a PR exists for the current branch, run `gh pr view <number> --comments` and read all CodeRabbit comments before proceeding.
+3. Do not make any edits until outstanding CR findings are addressed or acknowledged.
+
+No exceptions.
 
 ## Trigger Prompt
 
@@ -44,9 +50,8 @@ Rules:
 - One logical change per commit. Do not bundle unrelated changes.
 - Commit after every meaningful change, not at the end of a long session.
 - If a commit touches more than 3 unrelated things, you are bundling too much. Split it.
-- If a new feature is added or changed, then update the top level README.md before commiting
-- before pushing changes wait for code rabbit to review, and add its recomendations to .claude\S&P.md
-- review S&P.md when makeing changes to the codebase
+- If a new feature is added or changed, update the top-level README.md before committing.
+- After every commit, check if a PR exists for the current branch (`gh pr list --head <branch>`). If none exists, open one immediately via `gh pr create`. Never leave a commit on a feature branch without an open PR.
 
 ## Rule 3: Report Fixer Must Never Merge to `stable`
 
@@ -61,12 +66,12 @@ Rules:
 
 ## Rule 4: Semantic Versioning
 
-update git hub releases on minor version changes of `stable`
+Update GitHub releases on minor version changes to the production branch.
 
 Tag releases using `vMAJOR.MINOR.PATCH`:
-- **MAJOR** -- breaking changes (removed features, changed APIs, incompatible updates)
-- **MINOR** -- new features that do not break existing functionality
-- **PATCH** -- bug fixes, typo corrections, minor improvements
+- **MAJOR** — breaking changes (removed features, changed APIs, incompatible updates)
+- **MINOR** — new features that do not break existing functionality
+- **PATCH** — bug fixes, typo corrections, minor improvements
 
 ## Rule 5: CodeRabbit Pull Request Reviews
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,96 @@
+# Auto Version Control Rules - Claude AI
+
+You are a senior software developer. These rules override your default behavior. Follow them on every action without being asked.
+
+## Rule 0: Always Read First
+
+Before taking any action on this project — including edits, commits, or file creation — read `.claude/CLAUDE.md` and `.claude/S&P.md`. No exceptions.
+
+## Trigger Prompt
+
+When the user says **"run auto version control"** (or any close variation like "run avc", "auto version control", "start version control"), immediately run the full assessment:
+
+1. Run `git status`, `git branch`, and `git log --oneline -10`
+2. Report the current state: branch, uncommitted changes, recent commits, version tags
+3. Flag any issues: working on main, uncommitted changes, missing .gitignore, no tags
+4. Recommend next actions
+
+This is how the user explicitly asks you to check in on the project.
+
+## Rule 1: Git Is Mandatory
+
+- If the project is not a git repository, run `git init` and create an initial commit before doing anything else.
+- Never work directly on `main`, `master`,`stable` . Always create a feature branch first then merge into `stable` and `PSM stable`.
+- Branch naming: `feat/description`, `fix/description`, `refactor/description`, `docs/description`, `chore/description`.
+- If you are on `main` when you start, create and switch to a feature branch immediately.
+
+## Rule 2: Conventional Commits
+
+Every commit message must follow this format:
+
+```
+type: short description (imperative, lowercase, no period)
+```
+
+Valid types: `feat`, `fix`, `refactor`, `docs`, `test`, `style`, `perf`, `chore`, `ci`, `build`.
+
+Examples:
+- `feat: add user authentication endpoint`
+- `fix: prevent null pointer in payment handler`
+- `refactor: extract validation logic into shared module`
+- `docs: add API usage examples to README`
+
+Rules:
+- One logical change per commit. Do not bundle unrelated changes.
+- Commit after every meaningful change, not at the end of a long session.
+- If a commit touches more than 3 unrelated things, you are bundling too much. Split it.
+- If a new feature is added or changed, then update the top level README.md before commiting
+- before pushing changes wait for code rabbit to review, and add its recomendations to .claude\S&P.md
+- review S&P.md when makeing changes to the codebase
+
+## Rule 3: Report Fixer Must Never Merge to `stable`
+
+**`modules/reporting/` (Report Fixer) is a PSM-only feature. It must never be merged into `stable`.**
+
+- `stable` is the primary production branch for general use. Report Fixer does not belong there.
+- Development happens on `PSM-stable`. When changes from `PSM-stable` are candidates for `stable`, always exclude `modules/reporting/` and its PSM-only dependencies (`pandas`, `openpyxl`) from the merge.
+- If Report Fixer files are detected in a diff or staged commit targeting `stable`, **stop immediately and warn the user** before taking any action.
+- This rule applies regardless of how the merge is initiated (manual, cherry-pick, or automated).
+
+---
+
+## Rule 4: Semantic Versioning
+
+update git hub releases on minor version changes of `stable`
+
+Tag releases using `vMAJOR.MINOR.PATCH`:
+- **MAJOR** -- breaking changes (removed features, changed APIs, incompatible updates)
+- **MINOR** -- new features that do not break existing functionality
+- **PATCH** -- bug fixes, typo corrections, minor improvements
+
+## Rule 5: CodeRabbit Pull Request Reviews
+
+When a pull request is open or being prepared:
+
+- Always open PRs via `gh pr create` — never merge directly to `master` without a PR.
+- After CodeRabbit submits its review, read the review comments before making any further changes.
+- For each CodeRabbit finding:
+  1. If it matches an existing `.claude/S&P.md` entry — fix it immediately and reference the S&P entry in the commit message.
+  2. If it is a new pattern — fix it, then append it to `.claude/S&P.md` in the standard format before committing.
+- Do not dismiss or ignore CodeRabbit nitpicks — log them to `.claude/S&P.md` even if not immediately actionable.
+- Only merge a PR after all blocking CodeRabbit comments are resolved.
+
+### S&P.md Entry Format
+
+```markdown
+## YYYY-MM-DD — `path/to/file.py` (short description)
+
+**Review:** WHAT CODERABBIT FLAGGED
+**Result:** outcome / resolution
+
+### Findings
+
+1. **Title**
+   - Detail
+   - Fix applied
+```

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -1,0 +1,25 @@
+# Standards & Practices — CodeRabbit Review Log
+
+This file records CodeRabbit recommendations so they can be applied to future changes.
+Review this file before making changes to the codebase.
+
+---
+
+## 2026-04-06 — `modules/search/module.py` (hidden file filter)
+
+**Review:** FILTER HIDDEN ENTRIES FROM FOLDER-CONTENTS PANEL
+**Result:** No issues detected. 3 nitpicks.
+
+### Nitpicks (all resolved in `fix/coderabbit-hidden-file-nitpicks`)
+
+1. **Hoist helper functions out of inner scopes**
+   - Do not define helper functions (e.g. `_is_hidden`) inside a method — they are recreated on every call.
+   - Move them to module level or class level.
+
+2. **Sort directories before files**
+   - `key=lambda n: (os.path.isdir(...), n.lower())` sorts files before dirs (`False < True`).
+   - Use `not os.path.isdir(...)` to put directories first, consistent with OS file browser conventions.
+
+3. **Avoid broad `except Exception`**
+   - Catch specific exceptions instead (e.g. `AttributeError`, `OSError`).
+   - Broad catches can silently mask unexpected errors.

--- a/.claude/hooks/pre_commit_sp_check.py
+++ b/.claude/hooks/pre_commit_sp_check.py
@@ -1,0 +1,87 @@
+"""
+Pre-commit S&P.md pattern checker for Claude Code (Windows-compatible).
+Triggered via PreToolUse hook on Bash tool calls.
+Reads tool input JSON from stdin, skips non-commit commands,
+then checks the staged diff against known S&P.md anti-patterns.
+"""
+
+import sys
+import json
+import re
+import subprocess
+
+
+def get_staged_diff() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--cached"],
+            capture_output=True, text=True
+        )
+        return result.stdout
+    except Exception:
+        return ""
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+        command = data.get("command", "")
+    except Exception:
+        sys.exit(0)
+
+    # Only run on git commit commands
+    if not re.search(r"git\s+commit", command):
+        sys.exit(0)
+
+    diff = get_staged_diff()
+    if not diff:
+        sys.exit(0)
+
+    added_lines = [line for line in diff.splitlines() if line.startswith("+") and not line.startswith("+++")]
+
+    warnings = []
+
+    # ---------------------------------------------------------------
+    # S&P checks — add new entries here as CodeRabbit reviews land
+    # ---------------------------------------------------------------
+
+    # [2026-04-06] Broad except Exception
+    for line in added_lines:
+        if re.search(r"except\s+Exception\b", line):
+            warnings.append(
+                "Broad 'except Exception' detected — use specific exceptions (e.g. OSError, AttributeError). [S&P 2026-04-06]"
+            )
+            break
+
+    # [2026-04-06] Helper functions defined inside methods (8+ spaces = nested scope)
+    for line in added_lines:
+        if re.search(r"^\+\s{8,}def\s+_\w+", line):
+            warnings.append(
+                "Private helper function defined inside a method — move to class or module level. [S&P 2026-04-06]"
+            )
+            break
+
+    # [2026-04-06] Sort key puts files before dirs (isdir without not)
+    for line in added_lines:
+        if re.search(r"key\s*=\s*lambda.*os\.path\.isdir", line) and not re.search(r"not\s+os\.path\.isdir", line):
+            warnings.append(
+                "Sort key may put files before directories — use 'not os.path.isdir(...)' to sort dirs first. [S&P 2026-04-06]"
+            )
+            break
+
+    # ---------------------------------------------------------------
+
+    if warnings:
+        print()
+        print(f"S&P.md Pre-commit Check — {len(warnings)} issue(s) found:")
+        for w in warnings:
+            print(f"  * {w}")
+        print()
+        print("Review S&P.md before proceeding. Commit is NOT blocked — fix on next commit if intentional.")
+        print()
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python .claude/hooks/pre_commit_sp_check.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/log-coderabbit-review.yml
+++ b/.github/workflows/log-coderabbit-review.yml
@@ -1,0 +1,47 @@
+name: Log CodeRabbit Review to S&P.md
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  log-review:
+    if: github.event.review.user.login == 'coderabbitai[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Append CodeRabbit review to .claude/S&P.md
+        env:
+          REVIEW_BODY: ${{ github.event.review.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          REVIEW_DATE: ${{ github.event.review.submitted_at }}
+        run: |
+          DATE=$(echo "$REVIEW_DATE" | cut -c1-10)
+          PR_REF="PR #${PR_NUMBER}: ${PR_TITLE}"
+
+          {
+            echo ""
+            echo "---"
+            echo ""
+            echo "## ${DATE} — \`${PR_REF}\`"
+            echo ""
+            echo "${REVIEW_BODY}"
+          } >> .claude/S&P.md
+
+      - name: Commit S&P.md update
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .claude/S&P.md
+          git diff --cached --quiet || git commit -m "docs: log coderabbit review for PR #${{ github.event.pull_request.number }}"
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ sample_files/
 test_jobs.csv
 
 # Claude Code and development notes
-.claude/
+.claude/settings.local.json
 .github-push-checklist.md
 docs/
 


### PR DESCRIPTION
## Summary
- Syncs `stable` into `PSM-stable` — brings in Claude Code + CodeRabbit setup
- Adds `.claude/` tracking, pre-commit S&P hook, GitHub Action for auto-logging reviews
- No Report Fixer or PSM-only files are affected

## Commits included
- `chore: add Claude Code + CodeRabbit setup from install template`
- `docs: update CLAUDE.md with template improvements`

## Test plan
- [ ] Confirm `modules/reporting/` is untouched after merge
- [ ] Confirm `.claude/settings.local.json` is not tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)