### PR TITLE
fix: remove inspection reports feature

### DIFF
--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -2389,3 +2389,167 @@ Reviewing files that changed from the base of the PR and between 2b20225f0e90a3d
 </details>
 
 <!-- This is an auto-generated comment by CodeRabbit for review status -->
+
+---
+
+## 2026-04-08 — `PR #7: fix: remove inspection reports feature` — review run 1
+
+
+
+<details>
+<summary>🧹 Nitpick comments (2)</summary><blockquote>
+
+<details>
+<summary>modules/quote/module.py (1)</summary><blockquote>
+
+`497-510`: **Remove stale “report(s)” wording from link log message.**
+
+Line 510 still mentions reports, which contradicts the drawings-only behavior and this PR’s objective.
+
+
+<details>
+<summary>Proposed text fix</summary>
+
+```diff
+-                    self.log_message(f"Linked {files_added} drawing(s)/report(s)")
++                    self.log_message(f"Linked {files_added} drawing(s)")
+```
+</details>
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In `@modules/quote/module.py` around lines 497 - 510, The log message in the
+drawing-linking flow still says "drawing(s)/report(s)" which is stale; in the
+method where the DrawingSearchDialog is used (the block creating dialog =
+DrawingSearchDialog(self.get_widget(), self.app_context) and iterating
+selected_files in the same function), update the process that calls
+self.log_message(...) to use wording that only references drawings (e.g.,
+"Linked {files_added} drawing(s)") so the message matches the drawings-only
+behavior; keep the variable files_added and the existing pluralization format
+intact.
+```
+
+</details>
+
+</blockquote></details>
+<details>
+<summary>modules/job/module.py (1)</summary><blockquote>
+
+`531-544`: **Update link log message to match drawings-only behavior.**
+
+Line 544 still contains “report(s)”, which is inconsistent with the updated dialog purpose.
+
+
+<details>
+<summary>Proposed text fix</summary>
+
+```diff
+-                    self.log_message(f"Linked {files_added} drawing(s)/report(s)")
++                    self.log_message(f"Linked {files_added} drawing(s)")
+```
+</details>
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In `@modules/job/module.py` around lines 531 - 544, The log message after linking
+files still says "Linked {files_added} drawing(s)/report(s)" which is
+inconsistent with the drawings-only dialog (DrawingSearchDialog); update the
+call to self.log_message in this method to only reference drawings (e.g.,
+"Linked {files_added} drawing(s)") so it matches the UI behavior and the items
+added to self.job_files/self.job_files_list.
+```
+
+</details>
+
+</blockquote></details>
+
+</blockquote></details>
+
+<details>
+<summary>🤖 Prompt for all review comments with AI agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+Nitpick comments:
+In `@modules/job/module.py`:
+- Around line 531-544: The log message after linking files still says "Linked
+{files_added} drawing(s)/report(s)" which is inconsistent with the drawings-only
+dialog (DrawingSearchDialog); update the call to self.log_message in this method
+to only reference drawings (e.g., "Linked {files_added} drawing(s)") so it
+matches the UI behavior and the items added to
+self.job_files/self.job_files_list.
+
+In `@modules/quote/module.py`:
+- Around line 497-510: The log message in the drawing-linking flow still says
+"drawing(s)/report(s)" which is stale; in the method where the
+DrawingSearchDialog is used (the block creating dialog =
+DrawingSearchDialog(self.get_widget(), self.app_context) and iterating
+selected_files in the same function), update the process that calls
+self.log_message(...) to use wording that only references drawings (e.g.,
+"Linked {files_added} drawing(s)") so the message matches the drawings-only
+behavior; keep the variable files_added and the existing pluralization format
+intact.
+```
+
+</details>
+
+---
+
+<details>
+<summary>ℹ️ Review info</summary>
+
+<details>
+<summary>⚙️ Run configuration</summary>
+
+**Configuration used**: Path: .coderabbit.yaml
+
+**Review profile**: CHILL
+
+**Plan**: Pro
+
+**Run ID**: `aac89868-4af1-48a7-bf17-10a94883c7c3`
+
+</details>
+
+<details>
+<summary>📥 Commits</summary>
+
+Reviewing files that changed from the base of the PR and between e31866f1abe4a4f72ca7044240df8f53d92ccbda and 1bf612c4361d4f54a65b3577925686f8c81520b4.
+
+</details>
+
+<details>
+<summary>📒 Files selected for processing (7)</summary>
+
+* `core/settings_dialog.py`
+* `main.py`
+* `modules/job/module.py`
+* `modules/quote/module.py`
+* `modules/search/module.py`
+* `modules/search/ui/search_tab.ui`
+* `shared/widgets.py`
+
+</details>
+
+<details>
+<summary>💤 Files with no reviewable changes (4)</summary>
+
+* core/settings_dialog.py
+* modules/search/module.py
+* main.py
+* modules/search/ui/search_tab.ui
+
+</details>
+
+</details>
+
+<!-- This is an auto-generated comment by CodeRabbit for review status -->

--- a/core/settings_dialog.py
+++ b/core/settings_dialog.py
@@ -66,14 +66,6 @@ class SettingsDialog(QDialog):
         cf_btn.clicked.connect(lambda: self.browse_dir(self.customer_files_edit))
         dir_layout.addWidget(cf_btn, 1, 2)
 
-        # Inspection reports
-        dir_layout.addWidget(QLabel("Inspection Reports Directory:"), 2, 0)
-        self.inspection_report_edit = QLineEdit(self.settings.get('inspection_report_dir', ''))
-        dir_layout.addWidget(self.inspection_report_edit, 2, 1)
-        ir_btn = QPushButton("Browse...")
-        ir_btn.clicked.connect(lambda: self.browse_dir(self.inspection_report_edit))
-        dir_layout.addWidget(ir_btn, 2, 2)
-
         scroll_layout.addWidget(dir_group)
 
         # ITAR directories group
@@ -305,7 +297,6 @@ class SettingsDialog(QDialog):
     def save(self):
         self.settings['blueprints_dir'] = self.blueprints_edit.text()
         self.settings['customer_files_dir'] = self.customer_files_edit.text()
-        self.settings['inspection_report_dir'] = self.inspection_report_edit.text()
         self.settings['itar_blueprints_dir'] = self.itar_blueprints_edit.text()
         self.settings['itar_customer_files_dir'] = self.itar_customer_files_edit.text()
 

--- a/main.py
+++ b/main.py
@@ -47,7 +47,6 @@ class JobDocsMainWindow(QMainWindow):
         'db_password': '',
         'remote_server_path': '',  # Network path or URL for remote settings sync
         'report_template_path': '',  # Path to Excel template for Report Fixer
-        'inspection_report_dir': '',  # Directory containing inspection reports
         'suppress_bp_link_notification': False,  # Suppress "linked to blueprints" confirmation dialog
         'skip_image_attachments': True
     }

--- a/modules/job/module.py
+++ b/modules/job/module.py
@@ -541,7 +541,7 @@ class JobModule(BaseModule):
                         self.job_files_list.addItem(os.path.basename(file_path))
                         files_added += 1
                 if files_added > 0:
-                    self.log_message(f"Linked {files_added} drawing(s)/report(s)")
+                    self.log_message(f"Linked {files_added} drawing(s)")
 
     def _copy_info_from_folder(self, folder_path: str):
         """Copy job/quote info from folder to form, including optional file copy"""

--- a/modules/job/module.py
+++ b/modules/job/module.py
@@ -528,7 +528,7 @@ class JobModule(BaseModule):
                 self._copy_info_from_folder(folder_path)
 
     def show_link_drawings_dialog(self):
-        """Show dialog to search and link existing drawings/inspection reports by drawing number"""
+        """Show dialog to search and link existing drawings by drawing number"""
         dialog = DrawingSearchDialog(self.get_widget(), self.app_context)
 
         if dialog.exec():

--- a/modules/quote/module.py
+++ b/modules/quote/module.py
@@ -494,7 +494,7 @@ class QuoteModule(BaseModule):
                 self._copy_info_from_folder(folder_path)
 
     def show_link_drawings_dialog(self):
-        """Show dialog to search and link existing drawings/inspection reports by drawing number"""
+        """Show dialog to search and link existing drawings by drawing number"""
         dialog = DrawingSearchDialog(self.get_widget(), self.app_context)
 
         if dialog.exec():

--- a/modules/quote/module.py
+++ b/modules/quote/module.py
@@ -507,7 +507,7 @@ class QuoteModule(BaseModule):
                         self.quote_files_list.addItem(os.path.basename(file_path))
                         files_added += 1
                 if files_added > 0:
-                    self.log_message(f"Linked {files_added} drawing(s)/report(s)")
+                    self.log_message(f"Linked {files_added} drawing(s)")
 
     def _copy_info_from_folder(self, folder_path: str):
         """Copy job/quote info from folder to form, including optional file copy"""

--- a/modules/search/module.py
+++ b/modules/search/module.py
@@ -298,7 +298,6 @@ class SearchModule(BaseModule):
         self.search_all_radio = None
         self.search_strict_radio = None
         self.search_blueprints_check = None
-        self.search_inspection_check = None
         self.mode_row_widget = None
         self.legacy_options_widget = None
         self.search_btn = None
@@ -340,7 +339,6 @@ class SearchModule(BaseModule):
         self.search_all_radio = widget.search_all_radio
         self.search_strict_radio = widget.search_strict_radio
         self.search_blueprints_check = widget.search_blueprints_check
-        self.search_inspection_check = widget.search_inspection_check
         self.mode_row_widget = widget.mode_row_widget
         self.legacy_options_widget = widget.legacy_options_widget
         self.search_btn = widget.search_btn
@@ -495,12 +493,6 @@ class SearchModule(BaseModule):
             itar_bp_dir = self.app_context.get_setting('itar_blueprints_dir', '')
             if itar_bp_dir and os.path.exists(itar_bp_dir):
                 dirs_to_search.append(('ITAR-BP', itar_bp_dir))
-
-        # Optionally search inspection reports directory
-        if self.search_inspection_check.isChecked():
-            ir_dir = self.app_context.get_setting('inspection_report_dir', '')
-            if ir_dir and os.path.exists(ir_dir):
-                dirs_to_search.append(('IR', ir_dir))
 
         # Determine which fields to search
         if strict_mode:

--- a/modules/search/ui/search_tab.ui
+++ b/modules/search/ui/search_tab.ui
@@ -282,16 +282,6 @@
           </widget>
          </item>
          <item>
-          <widget class="QCheckBox" name="search_inspection_check">
-           <property name="text">
-            <string>Inspection Reports</string>
-           </property>
-           <property name="checked">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
           <spacer name="horizontalSpacer_4">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>

--- a/shared/widgets.py
+++ b/shared/widgets.py
@@ -1066,14 +1066,14 @@ class FileCopyDialog(QDialog):
 
 
 class DrawingSearchDialog(QDialog):
-    """Dialog for searching and linking existing drawings and inspection reports by drawing number"""
+    """Dialog for searching and linking existing drawings by drawing number"""
 
     def __init__(self, parent, app_context):
         super().__init__(parent)
         self.app_context = app_context
         self.selected_files = []
 
-        self.setWindowTitle("Link Drawings & Inspection Reports")
+        self.setWindowTitle("Link Drawings")
         self.resize(750, 550)
 
         layout = QVBoxLayout(self)
@@ -1125,7 +1125,7 @@ class DrawingSearchDialog(QDialog):
         self.search_input.setFocus()
 
     def perform_search(self):
-        """Search for drawings and inspection reports matching the drawing number"""
+        """Search for drawings matching the drawing number"""
         search_term = self.search_input.text().strip().lower()
         self.results_tree.clear()
 
@@ -1136,7 +1136,6 @@ class DrawingSearchDialog(QDialog):
         # Get directories to search
         blueprints_dir = self.app_context.get_setting('blueprints_dir', '')
         itar_blueprints_dir = self.app_context.get_setting('itar_blueprints_dir', '')
-        inspection_dir = self.app_context.get_setting('inspection_report_dir', '')
 
         results = []
 
@@ -1144,7 +1143,6 @@ class DrawingSearchDialog(QDialog):
         for base_dir, location_prefix in [
             (blueprints_dir, 'Blueprints'),
             (itar_blueprints_dir, 'ITAR Blueprints'),
-            (inspection_dir, 'Inspection Reports')
         ]:
             if not base_dir or not os.path.exists(base_dir):
                 continue


### PR DESCRIPTION
## Summary

- Removes inspection reports from all user-facing surfaces (settings, search, drawing dialog)
- Feature preserved on `feat/qa-module` branch for future QA module development

## Files changed

- `core/settings_dialog.py` — remove Inspection Reports Directory field
- `main.py` — remove `inspection_report_dir` default
- `modules/search/module.py` — remove `search_inspection_check` binding and IR search logic
- `modules/search/ui/search_tab.ui` — remove checkbox widget
- `shared/widgets.py` — remove inspection dir from `DrawingSearchDialog`
- `modules/job/module.py`, `modules/quote/module.py` — update docstrings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the inspection reports directory setting and its UI controls from Settings.
  * Removed inspection reports from search and linking flows; users can now only search for and link drawings by drawing number.
  * Search/link dialogs and prompts now reference drawings exclusively.

* **Documentation**
  * Updated in-app text and help to clarify search and linking operate on drawings only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->