### PR TITLE
fix: remove leftover PO# checkbox and table column from search UI

### DIFF
--- a/modules/search/ui/search_tab.ui
+++ b/modules/search/ui/search_tab.ui
@@ -119,16 +119,6 @@
          </widget>
         </item>
         <item>
-         <widget class="QCheckBox" name="search_po_check">
-          <property name="text">
-           <string>PO #</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
          <widget class="QCheckBox" name="search_desc_check">
           <property name="text">
            <string>Description</string>
@@ -336,11 +326,6 @@
         <column>
          <property name="text">
           <string>Job #</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>PO #</string>
          </property>
         </column>
         <column>


### PR DESCRIPTION
## Summary

- Removes the `search_po_check` widget from `search_tab.ui` — it was never referenced in `module.py`, so it stayed enabled and checked while all other "Search in:" checkboxes were correctly grayed out in legacy mode
- Removes the `PO #` table column from the search results table — its presence caused a column offset bug where description data was displayed under "PO #" and drawings data under "Description"

## Test plan

- [ ] Open Search tab — no PO # checkbox visible in "Search in:" row
- [ ] Search results table columns are: Date, Customer, Job #, Description, Drawings (no PO #)
- [ ] Description and Drawings data appear in their correct columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Removed PO # search filter from search criteria
  * Removed PO # column from search results table

<!-- end of auto-generated comment: release notes by coderabbit.ai -->