### PR TITLE
ci: add build-release workflow for Windows exe (signing pending approval)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -81,7 +81,7 @@ Pushing a `v*` tag to `stable` automatically triggers `.github/workflows/build-r
 3. Creates a GitHub Release and attaches `JobDocs.exe` as a release asset
 
 **To cut a release:**
-```
+```bash
 git tag v1.2.3
 git push origin v1.2.3
 ```

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -73,6 +73,23 @@ Tag releases using `vMAJOR.MINOR.PATCH`:
 - **MINOR** — new features that do not break existing functionality
 - **PATCH** — bug fixes, typo corrections, minor improvements
 
+### Release Workflow
+
+Pushing a `v*` tag to `stable` automatically triggers `.github/workflows/build-release.yml`, which:
+1. Builds `JobDocs.exe` via PyInstaller on a Windows runner using `build_scripts/JobDocs.spec`
+2. Signs the executable via SignPath (once approved — currently commented out pending application)
+3. Creates a GitHub Release and attaches `JobDocs.exe` as a release asset
+
+**To cut a release:**
+```
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+**Note:** Only tag from `stable`. Do not push `v*` tags from `PSM-stable` — that branch carries Report Fixer (Rule 3) and must not produce a general release build.
+
+**SignPath:** Apply at https://signpath.io/product/open-source. Once approved, uncomment the signing step in `build-release.yml` and add `SIGNPATH_API_TOKEN` and `SIGNPATH_ORG_ID` to GitHub Actions secrets.
+
 ## Rule 5: CodeRabbit Pull Request Reviews
 
 When a pull request is open or being prepared:

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -2694,3 +2694,32 @@ Reviewing files that changed from the base of the PR and between f7451a9e5c1f0c4
 </details>
 
 <!-- This is an auto-generated comment by CodeRabbit for review status -->
+
+---
+
+## 2026-04-09 — `.github/workflows/build-release.yml` (PR #9: build-release workflow — review run 1)
+
+**Review:** CODERABBIT FINDINGS ON INITIAL BUILD-RELEASE WORKFLOW
+**Result:** All 4 actionable findings fixed; 1 nitpick (SHA pinning) deferred
+
+### Findings
+
+1. **MD040 — Missing language identifier on code fence in CLAUDE.md**
+   - Code fence for `git tag` commands lacked a language identifier
+   - Fix: added `bash` to opening fence
+
+2. **No stable-ancestry guard on tag trigger**
+   - Workflow could fire on tags pushed from any branch, including PSM-stable
+   - Fix: added `verify-stable-ancestry` job that runs `git merge-base --is-ancestor origin/stable $GITHUB_SHA` before build
+
+3. **Dependency version mismatch — PyMuPDF pinned loosely in workflow**
+   - Workflow used `PyMuPDF>=1.23.0`; `requirements.txt` pins `pymupdf>=1.24.0,<1.25.0`
+   - Fix: changed install step to `pip install -r requirements.txt` to match tested baseline
+
+4. **SignPath step ordering — unsigned artifact must upload before signing**
+   - SignPath action reads from an uploaded artifact; release should use signed output
+   - Fix: moved `upload-artifact` before the SignPath block; added commented `download-artifact` scaffold for when signing is enabled
+
+5. **Nitpick — Pin GitHub Actions to commit SHAs (deferred)**
+   - Floating major version tags (`@v4`, `@v5`, `@v2`) weaken supply-chain guarantees
+   - Deferred: acceptable risk for now; revisit when SHA pinning tooling is in place

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -2553,3 +2553,144 @@ Reviewing files that changed from the base of the PR and between e31866f1abe4a4f
 </details>
 
 <!-- This is an auto-generated comment by CodeRabbit for review status -->
+
+---
+
+## 2026-04-09 — `PR #9: ci: add build-release workflow for signed Windows exe` — review run 1
+
+**Actionable comments posted: 4**
+
+<details>
+<summary>🧹 Nitpick comments (1)</summary><blockquote>
+
+<details>
+<summary>.github/workflows/build-release.yml (1)</summary><blockquote>
+
+`16-16`: **Pin GitHub Actions to commit SHAs.**
+
+Floating major version tags (`@v4`, `@v5`, `@v2`) weaken supply-chain guarantees. Pin to full commit SHAs for `actions/checkout`, `actions/setup-python`, `actions/upload-artifact`, and `softprops/action-gh-release`.
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In @.github/workflows/build-release.yml at line 16, The workflow currently uses
+floating tags like "uses: actions/checkout@v4" which weakens supply-chain
+guarantees; update each third-party action reference (e.g., actions/checkout@v4,
+actions/setup-python@..., actions/upload-artifact@...,
+softprops/action-gh-release@...) to pin to the corresponding full commit SHA for
+that action repository instead of the major/minor tag, replacing the tag strings
+with the exact commit SHAs so each "uses:" entry references a specific immutable
+commit.
+```
+
+</details>
+
+</blockquote></details>
+
+</blockquote></details>
+
+<details>
+<summary>🤖 Prompt for all review comments with AI agents</summary>
+
+````
+Verify each finding against the current code and only fix it if needed.
+
+Inline comments:
+In @.claude/CLAUDE.md:
+- Around line 84-87: The fenced code block containing the git commands ("git tag
+v1.2.3" and "git push origin v1.2.3") needs a language identifier to satisfy
+MD040; edit the fenced block in .claude/CLAUDE.md so the opening fence reads
+```bash (instead of just ```), preserving the two command lines and closing
+fence.
+
+In @.github/workflows/build-release.yml:
+- Around line 3-6: Add a guard that verifies the pushed tag's commit is
+descended from the stable branch before running the release workflow: create a
+pre-release job (e.g., verify-stable-ancestry) that runs on the tag event
+(on.push.tags) and uses actions/checkout to fetch origin stable, then run git
+merge-base --is-ancestor origin/stable $GITHUB_SHA (or equivalent git check) and
+fail the job if it returns non-zero; reference the job name
+verify-stable-ancestry and the CI env var GITHUB_SHA so the release job
+depends_on this verification step.
+- Around line 23-25: The CI step named "Install dependencies" currently installs
+PyMuPDF with a looser constraint (PyMuPDF>=1.23.0) which diverges from the
+tested baseline; update that step in the build-release.yml to install exact test
+requirements by running pip install -r requirements.txt (or, if you prefer
+minimal change, change the explicit package spec to match the baseline:
+pymupdf>=1.24.0,<1.25.0) so the workflow uses the same dependency bounds as the
+requirements file and ensures reproducible releases.
+- Around line 43-53: The SignPath step is referenced before the unsigned
+artifact is uploaded and the release publishes an unsigned binary; reorder the
+workflow so the job that creates and uploads the unsigned artifact (artifact
+name "JobDocs-unsigned") runs before the SignPath action
+(signpath/github-action-submit-signing-request@v1), then add a step after
+SignPath to download the signed artifact ("JobDocs-signed") and replace or point
+the release input at that signed file instead of build_dist/JobDocs.exe; ensure
+the GitHub Release step uses the downloaded "JobDocs-signed" artifact rather
+than the original unsigned file.
+
+---
+
+Nitpick comments:
+In @.github/workflows/build-release.yml:
+- Line 16: The workflow currently uses floating tags like "uses:
+actions/checkout@v4" which weakens supply-chain guarantees; update each
+third-party action reference (e.g., actions/checkout@v4,
+actions/setup-python@..., actions/upload-artifact@...,
+softprops/action-gh-release@...) to pin to the corresponding full commit SHA for
+that action repository instead of the major/minor tag, replacing the tag strings
+with the exact commit SHAs so each "uses:" entry references a specific immutable
+commit.
+````
+
+</details>
+
+<details>
+<summary>🪄 Autofix (Beta)</summary>
+
+Fix all unresolved CodeRabbit comments on this PR:
+
+- [ ] <!-- {"checkboxId": "4b0d0e0a-96d7-4f10-b296-3a18ea78f0b9"} --> Push a commit to this branch (recommended)
+- [ ] <!-- {"checkboxId": "ff5b1114-7d8c-49e6-8ac1-43f82af23a33"} --> Create a new PR with the fixes
+
+</details>
+
+---
+
+<details>
+<summary>ℹ️ Review info</summary>
+
+<details>
+<summary>⚙️ Run configuration</summary>
+
+**Configuration used**: Path: .coderabbit.yaml
+
+**Review profile**: CHILL
+
+**Plan**: Pro
+
+**Run ID**: `1c359722-1c07-474a-898b-7b07bc030558`
+
+</details>
+
+<details>
+<summary>📥 Commits</summary>
+
+Reviewing files that changed from the base of the PR and between f7451a9e5c1f0c425d6922a4fcb63918be861b7d and 62d0c5bb661c6bdbcca77b7cfa86eeb3306f4476.
+
+</details>
+
+<details>
+<summary>📒 Files selected for processing (2)</summary>
+
+* `.claude/CLAUDE.md`
+* `.github/workflows/build-release.yml`
+
+</details>
+
+</details>
+
+<!-- This is an auto-generated comment by CodeRabbit for review status -->

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,66 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install "PyQt6>=6.5.0" "PyMuPDF>=1.23.0" "pyinstaller>=6.0.0"
+
+      - name: Build executable
+        run: |
+          python -m PyInstaller --distpath build_dist --workpath build_temp build_scripts/JobDocs.spec
+
+      - name: Verify build
+        run: |
+          if (!(Test-Path "build_dist/JobDocs.exe")) {
+            Write-Error "build_dist/JobDocs.exe not found — build failed"
+            exit 1
+          }
+          Write-Output "Build OK: $(Get-Item build_dist/JobDocs.exe | Select-Object -ExpandProperty Length) bytes"
+
+      # -----------------------------------------------------------------------
+      # SignPath code signing — uncomment once SignPath Foundation is approved
+      # Apply at: https://signpath.io/product/open-source
+      # -----------------------------------------------------------------------
+      # - name: Sign executable
+      #   uses: signpath/github-action-submit-signing-request@v1
+      #   with:
+      #     api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+      #     organization-id: ${{ secrets.SIGNPATH_ORG_ID }}
+      #     project-slug: jobdocs
+      #     signing-policy-slug: release-signing
+      #     artifact-configuration-slug: single-exe
+      #     github-artifact-name: JobDocs-unsigned
+      #     output-artifact-name: JobDocs-signed
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: JobDocs-unsigned
+          path: build_dist/JobDocs.exe
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: JobDocs ${{ github.ref_name }}
+          files: build_dist/JobDocs.exe
+          generate_release_notes: true
+          fail_on_unmatched_files: true

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -6,7 +6,25 @@ on:
       - 'v*'
 
 jobs:
+  verify-stable-ancestry:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag is descended from stable
+        run: |
+          git fetch origin stable
+          if ! git merge-base --is-ancestor origin/stable "$GITHUB_SHA"; then
+            echo "ERROR: Tag $GITHUB_REF_NAME is not descended from stable. Only tag from stable."
+            exit 1
+          fi
+          echo "OK: $GITHUB_REF_NAME is descended from stable"
+
   build-windows:
+    needs: verify-stable-ancestry
     runs-on: windows-latest
     permissions:
       contents: write
@@ -22,7 +40,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install "PyQt6>=6.5.0" "PyMuPDF>=1.23.0" "pyinstaller>=6.0.0"
+          pip install -r requirements.txt
+          pip install "pyinstaller>=6.0.0"
 
       - name: Build executable
         run: |
@@ -36,9 +55,16 @@ jobs:
           }
           Write-Output "Build OK: $(Get-Item build_dist/JobDocs.exe | Select-Object -ExpandProperty Length) bytes"
 
+      - name: Upload unsigned artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: JobDocs-unsigned
+          path: build_dist/JobDocs.exe
+
       # -----------------------------------------------------------------------
       # SignPath code signing — uncomment once SignPath Foundation is approved
       # Apply at: https://signpath.io/product/open-source
+      # After enabling: update the release step below to use JobDocs-signed
       # -----------------------------------------------------------------------
       # - name: Sign executable
       #   uses: signpath/github-action-submit-signing-request@v1
@@ -51,16 +77,18 @@ jobs:
       #     github-artifact-name: JobDocs-unsigned
       #     output-artifact-name: JobDocs-signed
 
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: JobDocs-unsigned
-          path: build_dist/JobDocs.exe
+      # - name: Download signed artifact
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: JobDocs-signed
+      #     path: build_dist_signed
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           name: JobDocs ${{ github.ref_name }}
           files: build_dist/JobDocs.exe
+          # When signing is enabled, replace the line above with:
+          # files: build_dist_signed/JobDocs.exe
           generate_release_notes: true
           fail_on_unmatched_files: true


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/build-release.yml` — triggers on `v*` tags, builds `JobDocs.exe` via PyInstaller on `windows-latest`, and publishes a GitHub Release with the exe attached
- SignPath open-source code signing step included but commented out pending approval at signpath.io/product/open-source
- Updates `CLAUDE.md` Rule 4 with release procedure and tag instructions

## Test plan
- [ ] Merge to `stable`
- [ ] Push a `v*` tag and verify the workflow runs and attaches the exe to a GitHub Release
- [ ] After SignPath approval: add `SIGNPATH_API_TOKEN` and `SIGNPATH_ORG_ID` secrets, uncomment signing step, re-test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated release workflow that builds and publishes the Windows executable whenever version tags are pushed, ensuring consistent and reliable release artifacts.
  * Documented release process standards, including version tagging conventions and release workflow steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->