### PR TITLE
fix: install Pillow for PNG-to-ICO icon conversion in build workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          pip install "pyinstaller>=6.0.0"
+          pip install "pyinstaller>=6.0.0" "Pillow"
 
       - name: Build executable
         run: |

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          pip install "pyinstaller>=6.0.0" "Pillow"
+          pip install "pyinstaller>=6.0.0" "Pillow>=10.4.0,<12.0.0"
 
       - name: Build executable
         run: |


### PR DESCRIPTION
## Summary
- PyInstaller on Windows requires `.ico` format for the app icon
- `JobDocs.iconset` only contains `.png` files
- PyInstaller auto-converts if Pillow is installed — adds `Pillow` to the install step

## Test plan
- [ ] Merge to `stable`
- [ ] Retag `v0.5.0` to trigger a clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)