### PR TITLE
fix: handle Outlook search result drag-drop (multimaillistconversationrows)

### DIFF
--- a/shared/widgets.py
+++ b/shared/widgets.py
@@ -300,9 +300,27 @@ class DropZone(QFrame):
             return []
 
         web_data = DropZone._parse_chromium_web_mime(raw)
-        mail_info = web_data.get('maillistrow')
+        # New Outlook uses different keys depending on context (inbox, search results, etc.)
+        _ROW_KEYS = (
+            'maillistrow',
+            'multimaillistconversationrows',  # search results in New Outlook
+            'conversationlistrow',
+            'itemlistrow',
+            'mailrow',
+            'messagelistrow',
+        )
+        mail_info = None
+        for _key in _ROW_KEYS:
+            if isinstance(web_data.get(_key), dict):
+                mail_info = web_data[_key]
+                print(f'[DropZone] Chromium MIME key matched: {_key!r}', flush=True)
+                break
         if not isinstance(mail_info, dict):
-            print('[DropZone] maillistrow not found in Chromium MIME data', flush=True)
+            print(
+                f'[DropZone] No recognised mail row key in Chromium MIME data. '
+                f'Keys present: {list(web_data.keys())}',
+                flush=True,
+            )
             return []
 
         # New Outlook uses parallel arrays: subjects[], itemIds[], mailboxInfos[]


### PR DESCRIPTION
## Summary

- New Outlook uses `multimaillistconversationrows` as the Chromium MIME row key when dragging from **search results**, not `maillistrow` (used in inbox/folder views)
- Adds a priority list of known row keys so drag-drop works across all Outlook contexts: inbox, conversation list, and search results
- Replaces the debug key-dump logging with a clean single-line match log

## Test plan

- [x] Drag email from Outlook inbox → still works (maillistrow path)
- [x] Drag email from Outlook search results → now works (multimaillistconversationrows)
- [ ] Confirm attachments extracted correctly from search-result drag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Outlook mail drag-and-drop functionality to reliably work across multiple Outlook versions and Chromium variants. Improved error diagnostics with clearer messages and more helpful information to aid troubleshooting when mail data cannot be properly identified or located.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->