### PR TITLE
ci: add Linux Flatpak build to release workflow

### DIFF
--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -2723,3 +2723,252 @@ Reviewing files that changed from the base of the PR and between f7451a9e5c1f0c4
 5. **Nitpick — Pin GitHub Actions to commit SHAs (deferred)**
    - Floating major version tags (`@v4`, `@v5`, `@v2`) weaken supply-chain guarantees
    - Deferred: acceptable risk for now; revisit when SHA pinning tooling is in place
+
+---
+
+## 2026-04-12 — `PR #12: ci: add Linux Flatpak build to release workflow` — review run 1
+
+**Actionable comments posted: 3**
+
+> [!CAUTION]
+> Some comments are outside the diff and can’t be posted inline due to platform limitations.
+> 
+> 
+> 
+> <details>
+> <summary>⚠️ Outside diff range comments (1)</summary><blockquote>
+> 
+> <details>
+> <summary>.github/workflows/build-release.yml (1)</summary><blockquote>
+> 
+> `29-33`: _⚠️ Potential issue_ | _🟠 Major_
+> 
+> **Drop repository write scope from the build jobs.**
+> 
+> These jobs only read the repo and upload artifacts; neither operation requires `contents: write`. Keeping this scope on them increases blast radius if any build step, action, or dependency is compromised. Only `create-release` needs it to publish the GitHub Release.
+> 
+> 
+> 
+> <details>
+> <summary>Suggested change</summary>
+> 
+> ```diff
+>    build-windows:
+>      needs: verify-stable-ancestry
+>      runs-on: windows-latest
+>      permissions:
+> -      contents: write
+> +      contents: read
+> @@
+>    build-flatpak:
+>      needs: verify-stable-ancestry
+>      runs-on: ubuntu-latest
+>      permissions:
+> -      contents: write
+> +      contents: read
+> ```
+> </details>
+> 
+> Also applies to: 92-96
+> 
+> <details>
+> <summary>🤖 Prompt for AI Agents</summary>
+> 
+> ```
+> Verify each finding against the current code and only fix it if needed.
+> 
+> In @.github/workflows/build-release.yml around lines 29 - 33, Remove the
+> overly-broad repository write permission from the build jobs: in the
+> build-windows job (and the other build jobs with the same block) remove or
+> change the permissions block so it no longer sets contents: write; these jobs
+> only need read access and artifact upload rights, so limit to the minimal scopes
+> (or omit the permissions block to use defaults) and leave contents: write only
+> on the create-release job that actually publishes the GitHub Release (identify
+> and modify the permissions block inside the build-windows job and the equivalent
+> build jobs referenced later).
+> ```
+> 
+> </details>
+> 
+> </blockquote></details>
+> 
+> </blockquote></details>
+
+<details>
+<summary>🧹 Nitpick comments (1)</summary><blockquote>
+
+<details>
+<summary>.github/workflows/build-release.yml (1)</summary><blockquote>
+
+`61-66`: **Avoid uploading the same EXE twice while signing is disabled.**
+
+`JobDocs-unsigned` and `JobDocs-windows` currently contain the same `build_dist/JobDocs.exe`. Keeping one artifact until SignPath is enabled will simplify the release flow and cut redundant upload/storage cost.
+
+
+
+<details>
+<summary>Possible cleanup</summary>
+
+```diff
+-      - name: Upload unsigned artifact
+-        uses: actions/upload-artifact@v4
+-        with:
+-          name: JobDocs-unsigned
+-          path: build_dist/JobDocs.exe
+-
+       # -----------------------------------------------------------------------
+       # SignPath code signing — uncomment once SignPath Foundation is approved
+       # Apply at: https://signpath.io/product/open-source
+       # After enabling: update the create-release step to use JobDocs-signed
+       # -----------------------------------------------------------------------
+```
+</details>
+
+
+Also applies to: 83-87
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In @.github/workflows/build-release.yml around lines 61 - 66, The workflow is
+uploading the same build_dist/JobDocs.exe twice as artifacts named
+JobDocs-unsigned and JobDocs-windows; change the upload steps so only one
+artifact is produced when signing is disabled (e.g., guard the JobDocs-windows
+upload with the SignPath condition or remove the JobDocs-unsigned step and keep
+JobDocs-windows until signing is enabled). Update the steps labeled "Upload
+unsigned artifact" and the later "Upload signed/windows" step to reference the
+SignPath boolean (or a single upload step) and ensure only one artifact name
+(JobDocs-windows or JobDocs-unsigned) is used for build_dist/JobDocs.exe to
+avoid duplicate uploads.
+```
+
+</details>
+
+</blockquote></details>
+
+</blockquote></details>
+
+<details>
+<summary>🤖 Prompt for all review comments with AI agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+Inline comments:
+In @.github/workflows/build-release.yml:
+- Around line 107-115: The GitHub Actions job currently installs Python deps and
+runs PyInstaller on the runner (steps named "Install Python dependencies" and
+"Build PyInstaller binary"), which produces a binary tied to the host libc;
+instead build the executable inside the Flatpak SDK runtime so it links against
+org.freedesktop.Platform//23.08 instead of the runner. Change the workflow to
+run PyInstaller under the Flatpak SDK (for example via flatpak run
+--command=python3 org.freedesktop.Sdk//23.08 or use flatpak-builder / a
+container image matching the SDK) and move the dependency installation and the
+PyInstaller invocation into that SDK context (replace the two steps that run pip
+install and python -m PyInstaller with equivalent commands executed inside the
+Flatpak SDK), ensuring the built binary is produced within build_dist inside the
+SDK environment.
+
+In `@linux/flatpak/io.github.i_machine_things.JobDocs.metainfo.xml`:
+- Around line 2-34: The AppStream metadata is missing the required license tags:
+add a <metadata_license> and a <project_license> element inside the <component
+type="desktop-application"> for io.github.i_machine_things.JobDocs using
+appropriate SPDX identifiers (for example
+<metadata_license>CC0-1.0</metadata_license> and
+<project_license>GPL-3.0-or-later</project_license>) so appstreamcli/Flathub
+validation passes; ensure the tags are placed alongside the existing <name>,
+<summary>, and <url> elements within the component.
+
+In `@linux/flatpak/io.github.i_machine_things.JobDocs.yml`:
+- Around line 14-15: The manifest currently grants broad home access via the
+--filesystem=home flag; replace this with scoped permissions and explicit
+user-access flows: remove --filesystem=home, add a dedicated data path like
+--filesystem=xdg-data/JobDocs for app configuration/storage, and rely on file
+chooser portals (document portal usage) or explicit per-directory --filesystem
+entries only for directories users select (e.g., --filesystem=/path/to/project
+when consented). Ensure the YAML entry for filesystem reflects the scoped path
+and update any launch/install documentation to show how the app requests
+user-selected directories via portals instead of omnibus home access.
+
+---
+
+Outside diff comments:
+In @.github/workflows/build-release.yml:
+- Around line 29-33: Remove the overly-broad repository write permission from
+the build jobs: in the build-windows job (and the other build jobs with the same
+block) remove or change the permissions block so it no longer sets contents:
+write; these jobs only need read access and artifact upload rights, so limit to
+the minimal scopes (or omit the permissions block to use defaults) and leave
+contents: write only on the create-release job that actually publishes the
+GitHub Release (identify and modify the permissions block inside the
+build-windows job and the equivalent build jobs referenced later).
+
+---
+
+Nitpick comments:
+In @.github/workflows/build-release.yml:
+- Around line 61-66: The workflow is uploading the same build_dist/JobDocs.exe
+twice as artifacts named JobDocs-unsigned and JobDocs-windows; change the upload
+steps so only one artifact is produced when signing is disabled (e.g., guard the
+JobDocs-windows upload with the SignPath condition or remove the
+JobDocs-unsigned step and keep JobDocs-windows until signing is enabled). Update
+the steps labeled "Upload unsigned artifact" and the later "Upload
+signed/windows" step to reference the SignPath boolean (or a single upload step)
+and ensure only one artifact name (JobDocs-windows or JobDocs-unsigned) is used
+for build_dist/JobDocs.exe to avoid duplicate uploads.
+```
+
+</details>
+
+<details>
+<summary>🪄 Autofix (Beta)</summary>
+
+Fix all unresolved CodeRabbit comments on this PR:
+
+- [ ] <!-- {"checkboxId": "4b0d0e0a-96d7-4f10-b296-3a18ea78f0b9"} --> Push a commit to this branch (recommended)
+- [ ] <!-- {"checkboxId": "ff5b1114-7d8c-49e6-8ac1-43f82af23a33"} --> Create a new PR with the fixes
+
+</details>
+
+---
+
+<details>
+<summary>ℹ️ Review info</summary>
+
+<details>
+<summary>⚙️ Run configuration</summary>
+
+**Configuration used**: Path: .coderabbit.yaml
+
+**Review profile**: CHILL
+
+**Plan**: Pro
+
+**Run ID**: `985ec0eb-6726-45ab-9494-92e3d599ed12`
+
+</details>
+
+<details>
+<summary>📥 Commits</summary>
+
+Reviewing files that changed from the base of the PR and between 552c60246291a2a21d76bbc19effc4812ad6147f and 11521ce4e660fbdf11a56ae3ad89cf35bcdad3e6.
+
+</details>
+
+<details>
+<summary>📒 Files selected for processing (5)</summary>
+
+* `.github/workflows/build-release.yml`
+* `.gitignore`
+* `linux/flatpak/io.github.i_machine_things.JobDocs.desktop`
+* `linux/flatpak/io.github.i_machine_things.JobDocs.metainfo.xml`
+* `linux/flatpak/io.github.i_machine_things.JobDocs.yml`
+
+</details>
+
+</details>
+
+<!-- This is an auto-generated comment by CodeRabbit for review status -->

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -2971,4 +2971,28 @@ Reviewing files that changed from the base of the PR and between 552c60246291a2a
 
 </details>
 
-<!-- This is an auto-generated comment by CodeRabbit for review status -->
+## 2026-04-12 — `.github/workflows/build-release.yml` + `linux/flatpak/` (Flatpak build additions)
+
+**Review:** PR #12 — ci: add Linux Flatpak build to release workflow
+**Result:** 4 findings (1 critical, 3 major). Critical and two majors fixed; one major acknowledged with documented TODO.
+
+### Findings
+
+1. **Critical — `metainfo-license-missing` (appstreamcli validation failure)**
+   - AppStream metainfo requires both `<metadata_license>` and `<project_license>` or `flatpak-builder` aborts during `appstreamcli compose`.
+   - Fix: added `<metadata_license>CC0-1.0</metadata_license>` and `<project_license>MIT</project_license>` to `io.github.i_machine_things.JobDocs.metainfo.xml`.
+   - Confirmed: local `appstreamcli compose` passes after fix.
+
+2. **Major — glibc ABI mismatch between runner and Flatpak runtime**
+   - PyInstaller binary built on `ubuntu-latest` bundles host system libs (e.g. `libsystemd.so.0`) requiring a newer `GLIBC` version than the pinned Flatpak runtime provides.
+   - CR suggested building inside the Flatpak SDK; fix applied instead: upgraded manifest and CI cache key from `org.freedesktop.Platform//23.08` to `//24.08` (glibc 2.40), which covers the runner's requirements.
+   - Confirmed: app launches cleanly under the 24.08 sandbox locally.
+
+3. **Major — `--filesystem=home` grants unrestricted home access in Flatpak sandbox**
+   - Overly broad permission exposes unrelated files; Flathub would reject this.
+   - Root cause: `core/settings_dialog.py` uses `QFileDialog` directly without the XDG FileChooser portal, so the app must be able to access any user-selected directory.
+   - Acknowledged: `--filesystem=home` kept for now with an inline TODO comment. Portal-based dir picker should replace it in a future refactor.
+
+4. **Major (outside diff) — `contents: write` on build-only jobs**
+   - `build-windows` and `build-flatpak` only checkout code and upload artifacts; neither needs write access to repository contents.
+   - Fix: narrowed both jobs to `permissions: contents: read`. Only `create-release` retains `contents: write`.

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -127,9 +127,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local/share/flatpak
-          key: flatpak-runtime-freedesktop-23.08-${{ runner.arch }}
+          key: flatpak-runtime-freedesktop-24.08-${{ runner.arch }}
           restore-keys: |
-            flatpak-runtime-freedesktop-23.08-
+            flatpak-runtime-freedesktop-24.08-
 
       - name: Add Flathub remote
         run: flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
@@ -137,8 +137,8 @@ jobs:
       - name: Install Flatpak runtime
         run: |
           flatpak install --user -y flathub \
-            org.freedesktop.Platform//23.08 \
-            org.freedesktop.Sdk//23.08
+            org.freedesktop.Platform//24.08 \
+            org.freedesktop.Sdk//24.08
 
       - name: Stage files for Flatpak manifest
         run: |

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -30,7 +30,7 @@ jobs:
     needs: verify-stable-ancestry
     runs-on: windows-latest
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -93,7 +93,7 @@ jobs:
     needs: verify-stable-ancestry
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -23,6 +23,9 @@ jobs:
           fi
           echo "OK: $GITHUB_REF_NAME is descended from stable"
 
+  # ---------------------------------------------------------------------------
+  # Windows — PyInstaller single-file EXE
+  # ---------------------------------------------------------------------------
   build-windows:
     needs: verify-stable-ancestry
     runs-on: windows-latest
@@ -64,7 +67,7 @@ jobs:
       # -----------------------------------------------------------------------
       # SignPath code signing — uncomment once SignPath Foundation is approved
       # Apply at: https://signpath.io/product/open-source
-      # After enabling: update the release step below to use JobDocs-signed
+      # After enabling: update the create-release step to use JobDocs-signed
       # -----------------------------------------------------------------------
       # - name: Sign executable
       #   uses: signpath/github-action-submit-signing-request@v1
@@ -77,18 +80,124 @@ jobs:
       #     github-artifact-name: JobDocs-unsigned
       #     output-artifact-name: JobDocs-signed
 
-      # - name: Download signed artifact
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: JobDocs-signed
-      #     path: build_dist_signed
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: JobDocs-windows
+          path: build_dist/JobDocs.exe
+
+  # ---------------------------------------------------------------------------
+  # Linux — PyInstaller binary wrapped in a Flatpak bundle
+  # ---------------------------------------------------------------------------
+  build-flatpak:
+    needs: verify-stable-ancestry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Python dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install "pyinstaller>=6.0.0"
+
+      - name: Build PyInstaller binary
+        run: |
+          python -m PyInstaller --distpath build_dist --workpath build_temp build_scripts/JobDocs.spec
+
+      - name: Verify binary
+        run: |
+          test -f build_dist/JobDocs || { echo "build_dist/JobDocs not found — build failed"; exit 1; }
+          echo "Build OK: $(du -h build_dist/JobDocs | cut -f1)"
+
+      - name: Install Flatpak tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y flatpak flatpak-builder
+
+      - name: Cache Flatpak runtimes
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/flatpak
+          key: flatpak-runtime-freedesktop-23.08-${{ runner.arch }}
+          restore-keys: |
+            flatpak-runtime-freedesktop-23.08-
+
+      - name: Add Flathub remote
+        run: flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+
+      - name: Install Flatpak runtime
+        run: |
+          flatpak install --user -y flathub \
+            org.freedesktop.Platform//23.08 \
+            org.freedesktop.Sdk//23.08
+
+      - name: Stage files for Flatpak manifest
+        run: |
+          cp build_dist/JobDocs linux/flatpak/JobDocs
+          cp JobDocs.iconset/icon_256x256.png linux/flatpak/icon_256x256.png
+
+      - name: Build Flatpak
+        run: |
+          flatpak-builder \
+            --user \
+            --repo=flatpak-repo \
+            --force-clean \
+            flatpak-build \
+            linux/flatpak/io.github.i_machine_things.JobDocs.yml
+          flatpak build-bundle \
+            --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo \
+            flatpak-repo \
+            JobDocs-linux.flatpak \
+            io.github.i_machine_things.JobDocs
+
+      - name: Verify Flatpak bundle
+        run: |
+          test -f JobDocs-linux.flatpak || { echo "JobDocs-linux.flatpak not found — build failed"; exit 1; }
+          echo "Flatpak OK: $(du -h JobDocs-linux.flatpak | cut -f1)"
+
+      - name: Upload Linux artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: JobDocs-linux
+          path: JobDocs-linux.flatpak
+
+  # ---------------------------------------------------------------------------
+  # Release — combine both platform artifacts into a single GitHub Release
+  # ---------------------------------------------------------------------------
+  create-release:
+    needs: [build-windows, build-flatpak]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download Windows artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: JobDocs-windows
+          path: release-assets
+
+      - name: Download Linux artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: JobDocs-linux
+          path: release-assets
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           name: JobDocs ${{ github.ref_name }}
-          files: build_dist/JobDocs.exe
-          # When signing is enabled, replace the line above with:
-          # files: build_dist_signed/JobDocs.exe
+          files: release-assets/*
+          # When signing is enabled, re-download JobDocs-signed instead of
+          # JobDocs-windows above, and update files: accordingly.
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,15 @@ Thumbs.db
 test_output/
 old/
 
+# Flatpak — staged binary and icon (copied from build_dist/ by CI, not source files)
+linux/flatpak/JobDocs
+linux/flatpak/icon_256x256.png
+
+# Flatpak builder output
+flatpak-build/
+flatpak-repo/
+*.flatpak
+
 # Build artifacts (all platforms)
 installer_output/
 dist/

--- a/linux/flatpak/README.md
+++ b/linux/flatpak/README.md
@@ -1,0 +1,48 @@
+# JobDocs Flatpak
+
+This directory contains the files needed to build a Flatpak bundle for JobDocs.
+
+## Files
+
+- **`io.github.i_machine_things.JobDocs.yml`** — Flatpak manifest
+- **`io.github.i_machine_things.JobDocs.desktop`** — XDG desktop entry
+- **`io.github.i_machine_things.JobDocs.metainfo.xml`** — AppStream metadata
+
+The `JobDocs` binary and `icon_256x256.png` are **not committed** — they are staged
+here by the CI workflow (from `build_dist/` and `JobDocs.iconset/`) before
+`flatpak-builder` is invoked.
+
+## Building locally
+
+From the project root:
+
+```bash
+# 1. Build the PyInstaller binary
+python3 -m PyInstaller --distpath build_dist --workpath build_temp build_scripts/JobDocs.spec
+
+# 2. Stage the binary and icon
+cp build_dist/JobDocs linux/flatpak/JobDocs
+cp JobDocs.iconset/icon_256x256.png linux/flatpak/icon_256x256.png
+
+# 3. Build the Flatpak
+flatpak-builder --user --repo=flatpak-repo --force-clean \
+    flatpak-build linux/flatpak/io.github.i_machine_things.JobDocs.yml
+
+# 4. Bundle for distribution
+flatpak build-bundle \
+    --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo \
+    flatpak-repo JobDocs-linux.flatpak io.github.i_machine_things.JobDocs
+
+# 5. Install and run
+flatpak install --user --bundle JobDocs-linux.flatpak
+flatpak run io.github.i_machine_things.JobDocs
+```
+
+## Runtime
+
+Uses `org.freedesktop.Platform//24.08`. Install via Flathub if not already present:
+
+```bash
+flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+flatpak install --user flathub org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08
+```

--- a/linux/flatpak/io.github.i_machine_things.JobDocs.desktop
+++ b/linux/flatpak/io.github.i_machine_things.JobDocs.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=JobDocs
+GenericName=Job Document Manager
+Comment=Manage blueprint files and customer job directories
+Exec=JobDocs
+Icon=io.github.i_machine_things.JobDocs
+Type=Application
+Categories=Office;Database;
+Keywords=jobs;documents;blueprints;files;management;
+StartupNotify=true
+StartupWMClass=JobDocs

--- a/linux/flatpak/io.github.i_machine_things.JobDocs.metainfo.xml
+++ b/linux/flatpak/io.github.i_machine_things.JobDocs.metainfo.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.i_machine_things.JobDocs</id>
+
+  <name>JobDocs</name>
+  <summary>Manage blueprint files and customer job directories</summary>
+
+  <description>
+    <p>
+      JobDocs is a modular desktop tool for managing blueprint files and customer
+      job directories. It supports file linking, ITAR compliance workflows, and
+      comprehensive job tracking.
+    </p>
+    <ul>
+      <li>Auto-generate sequential job and quote numbers</li>
+      <li>Single and bulk job creation (CSV import)</li>
+      <li>Blueprint file management with hard-link deduplication</li>
+      <li>ITAR-controlled project separation</li>
+      <li>Advanced search by customer, job number, description, or drawing number</li>
+      <li>History tracking for recent jobs and customers</li>
+    </ul>
+  </description>
+
+  <url type="homepage">https://github.com/i-machine-things/JobDocs</url>
+  <url type="bugtracker">https://github.com/i-machine-things/JobDocs/issues</url>
+
+  <launchable type="desktop-id">io.github.i_machine_things.JobDocs.desktop</launchable>
+
+  <provides>
+    <binary>JobDocs</binary>
+  </provides>
+
+  <content_rating type="oars-1.1"/>
+</component>

--- a/linux/flatpak/io.github.i_machine_things.JobDocs.metainfo.xml
+++ b/linux/flatpak/io.github.i_machine_things.JobDocs.metainfo.xml
@@ -2,6 +2,9 @@
 <component type="desktop-application">
   <id>io.github.i_machine_things.JobDocs</id>
 
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+
   <name>JobDocs</name>
   <summary>Manage blueprint files and customer job directories</summary>
 

--- a/linux/flatpak/io.github.i_machine_things.JobDocs.yml
+++ b/linux/flatpak/io.github.i_machine_things.JobDocs.yml
@@ -1,0 +1,42 @@
+app-id: io.github.i_machine_things.JobDocs
+runtime: org.freedesktop.Platform
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
+command: JobDocs
+
+finish-args:
+  # Display — prefer Wayland, fall back to X11
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  # GPU acceleration for Qt rendering
+  - --device=dri
+  # File system access — JobDocs manages documents in user directories
+  - --filesystem=home
+
+modules:
+  - name: JobDocs
+    buildsystem: simple
+    # The PyInstaller binary and support files are staged into this directory
+    # by the CI workflow before flatpak-builder is invoked.
+    sources:
+      - type: file
+        path: JobDocs
+      - type: file
+        path: io.github.i_machine_things.JobDocs.desktop
+      - type: file
+        path: io.github.i_machine_things.JobDocs.metainfo.xml
+      - type: file
+        path: icon_256x256.png
+    build-commands:
+      # Install the PyInstaller single-file binary
+      - install -Dm755 JobDocs /app/bin/JobDocs
+      # Desktop entry
+      - install -Dm644 io.github.i_machine_things.JobDocs.desktop
+          /app/share/applications/io.github.i_machine_things.JobDocs.desktop
+      # AppStream metadata
+      - install -Dm644 io.github.i_machine_things.JobDocs.metainfo.xml
+          /app/share/metainfo/io.github.i_machine_things.JobDocs.metainfo.xml
+      # Application icon (256×256 used for the Flatpak bundle icon)
+      - install -Dm644 icon_256x256.png
+          /app/share/icons/hicolor/256x256/apps/io.github.i_machine_things.JobDocs.png

--- a/linux/flatpak/io.github.i_machine_things.JobDocs.yml
+++ b/linux/flatpak/io.github.i_machine_things.JobDocs.yml
@@ -11,7 +11,12 @@ finish-args:
   - --share=ipc
   # GPU acceleration for Qt rendering
   - --device=dri
-  # File system access — JobDocs manages documents in user directories
+  # File system access — JobDocs lets users configure an arbitrary root job
+  # directory anywhere inside their home tree (set via Settings dialog with
+  # QFileDialog). Narrowing this to xdg-data/JobDocs or individual paths would
+  # break that workflow until the app is ported to the XDG FileChooser portal.
+  # TODO: replace with --filesystem=xdg-data/JobDocs + portal-based dir picker
+  #       once core/settings_dialog.py uses QFileDialog with portal support.
   - --filesystem=home
 
 modules:

--- a/linux/flatpak/io.github.i_machine_things.JobDocs.yml
+++ b/linux/flatpak/io.github.i_machine_things.JobDocs.yml
@@ -1,6 +1,6 @@
 app-id: io.github.i_machine_things.JobDocs
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 command: JobDocs
 


### PR DESCRIPTION
## Summary

- Adds a `build-flatpak` job that builds a PyInstaller binary on Linux then wraps it in a Flatpak bundle (`io.github.i_machine_things.JobDocs`) using `org.freedesktop.Platform 23.08`
- Refactors the workflow into three jobs: `build-windows`, `build-flatpak`, and a new `create-release` job that downloads both artifacts and publishes a single GitHub Release with both `JobDocs.exe` and `JobDocs-linux.flatpak`
- Adds `linux/flatpak/` with Flatpak manifest, XDG desktop entry, and AppStream metainfo
- Extends `.gitignore` to exclude staged build files (`linux/flatpak/JobDocs`, `linux/flatpak/icon_256x256.png`) and Flatpak builder output

## Flatpak approach

Wraps the existing PyInstaller single-file binary rather than repackaging Python + Qt inside the Flatpak, keeping it consistent with the Windows build strategy. Flatpak runtime caching (`actions/cache@v4` on `~/.local/share/flatpak`) keeps repeat builds fast after the first cold download.

## Test plan

- [ ] Push a `v*` tag from `stable` and verify all three jobs complete
- [ ] Confirm the GitHub Release contains both `JobDocs.exe` and `JobDocs-linux.flatpak`
- [ ] Install the `.flatpak` bundle locally: `flatpak install JobDocs-linux.flatpak`
- [ ] Launch and verify the app runs correctly inside the Flatpak sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Flatpak distribution format support for Linux, enabling users to install and update the application through standard Linux package managers with improved system integration.

* **Chores**
  * Enhanced CI/CD pipeline to automate building, packaging, and distributing artifacts for multiple platforms.
  * Configured comprehensive build system for Linux Flatpak application bundling with proper desktop metadata and icon integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->