### PR TITLE
chore: deprecate local build scripts in favour of CI workflow

### DIFF
--- a/build_scripts/build_linux.sh
+++ b/build_scripts/build_linux.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+# DEPRECATED — local build script for Linux.
+#
+# Official Linux builds are now produced by the CI/CD release workflow:
+#   .github/workflows/build-release.yml (job: build-flatpak)
+#
+# The workflow builds a PyInstaller binary and wraps it in a Flatpak bundle
+# (JobDocs-linux.flatpak), which is attached to every GitHub Release.
+#
+# For local Flatpak builds, see: linux/flatpak/README.md
+#
+# This script (raw PyInstaller binary, no Flatpak) is kept for reference
+# but is no longer the recommended build path.
+# ---------------------------------------------------------------------------
 # Build script for JobDocs on Linux
 # Creates a standalone executable using PyInstaller
 

--- a/build_scripts/build_windows.bat
+++ b/build_scripts/build_windows.bat
@@ -1,4 +1,16 @@
 @echo off
+REM DEPRECATED — local build script for Windows.
+REM
+REM Official Windows builds are now produced by the CI/CD release workflow:
+REM   .github/workflows/build-release.yml (job: build-windows)
+REM
+REM The workflow builds JobDocs.exe via PyInstaller and attaches it to every
+REM GitHub Release. Download the latest release from:
+REM   https://github.com/i-machine-things/JobDocs/releases
+REM
+REM This script (local build + Program Files install + shortcut helper) is kept
+REM for developer use but is no longer the canonical distribution path.
+REM ---------------------------------------------------------------------------
 REM Build script for JobDocs on Windows
 REM Creates a standalone executable using PyInstaller
 

--- a/windows/build_windows_installer.bat
+++ b/windows/build_windows_installer.bat
@@ -1,4 +1,16 @@
 @echo off
+REM DEPRECATED — Inno Setup installer build script.
+REM
+REM Installer-based distribution was superseded by the CI/CD release workflow:
+REM   .github/workflows/build-release.yml
+REM
+REM The workflow produces a standalone JobDocs.exe (no installer required)
+REM attached to every GitHub Release. Download from:
+REM   https://github.com/i-machine-things/JobDocs/releases
+REM
+REM This script (Inno Setup .exe installer) is kept for reference but is no
+REM longer maintained or tested.
+REM ---------------------------------------------------------------------------
 REM Build Windows Installer for JobDocs
 REM This script builds the executable and creates an installer using Inno Setup
 


### PR DESCRIPTION
## Summary

Adds `DEPRECATED` headers to all three local build scripts now that the CI/CD release workflow covers both platforms end-to-end.

| Script | Superseded by |
|---|---|
| `build_scripts/build_linux.sh` | `build-flatpak` CI job + `linux/flatpak/README.md` |
| `build_scripts/build_windows.bat` | `build-windows` CI job + GitHub Releases |
| `windows/build_windows_installer.bat` | Standalone EXE distribution via CI (no installer needed) |

Scripts are **kept, not deleted** — they still work for local dev builds and the Windows script includes useful extras (Program Files install, shortcut helper) that CI doesn't do.

## Test plan

- [ ] Confirm headers render correctly (no shell/batch syntax errors introduced)
- [ ] Verify scripts still execute successfully after the comment additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local build scripts with deprecation notices and references to official CI/CD workflows.
  * Users directed to GitHub Releases for official distributions: Linux Flatpak bundles and Windows standalone executables.
  * Local scripts retained for advanced developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->