### PR TITLE
build: convert to onedir and add Inno Setup Windows installer

### DIFF
--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -2996,3 +2996,147 @@ Reviewing files that changed from the base of the PR and between 552c60246291a2a
 4. **Major (outside diff) — `contents: write` on build-only jobs**
    - `build-windows` and `build-flatpak` only checkout code and upload artifacts; neither needs write access to repository contents.
    - Fix: narrowed both jobs to `permissions: contents: read`. Only `create-release` retains `contents: write`.
+
+---
+
+## 2026-04-13 — `PR #14: build: convert to onedir and add Inno Setup Windows installer` — review run 1
+
+**Actionable comments posted: 1**
+
+<details>
+<summary>🧹 Nitpick comments (1)</summary><blockquote>
+
+<details>
+<summary>.github/workflows/build-release.yml (1)</summary><blockquote>
+
+`77-81`: **Provision or at least assert `iscc` before invoking it.**
+
+Line 80 invokes `iscc build_scripts\JobDocs.iss` without installing or validating Inno Setup. This makes the Windows release job depend on the hosted runner image's toolset rather than a declared build dependency, which risks pipeline failures if the image configuration changes.
+
+<details>
+<summary>♻️ Minimal guard</summary>
+
+```diff
++      - name: Verify Inno Setup is available
++        run: |
++          if (!(Get-Command iscc -ErrorAction SilentlyContinue)) {
++            Write-Error "iscc not found on PATH"
++            exit 1
++          }
++        shell: pwsh
++
+       - name: Build Windows installer
+         run: |
+           $env:RELEASE_VERSION = "${{ github.ref_name }}"
+           iscc build_scripts\JobDocs.iss
+         shell: pwsh
+```
+</details>
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In @.github/workflows/build-release.yml around lines 77 - 81, The "Build Windows
+installer" step calls the external tool "iscc" (iscc build_scripts\JobDocs.iss)
+without ensuring Inno Setup is available; add a guard that either installs Inno
+Setup (for example via Chocolatey) or asserts presence and fails fast: use a
+PowerShell check like Get-Command iscc -ErrorAction SilentlyContinue and if
+missing run choco install innosetup --confirm (or exit with a clear error), then
+proceed to set $env:RELEASE_VERSION and run iscc; update the step that currently
+contains "iscc build_scripts\JobDocs.iss" to include this installation/check
+sequence so the job no longer depends on the runner image having iscc
+preinstalled.
+```
+
+</details>
+
+</blockquote></details>
+
+</blockquote></details>
+
+<details>
+<summary>🤖 Prompt for all review comments with AI agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+Inline comments:
+In @.github/workflows/build-release.yml:
+- Around line 142-145: The workflow currently copies only the launcher binary
+(cp dist/JobDocs/JobDocs) which omits the PyInstaller onedir runtime files;
+change the staging step to copy the entire onedir tree (recursively stage the
+dist/JobDocs directory into the flatpak staging dir) so all libraries and data
+are included, and then update the Flatpak manifest's handling of JobDocs (the
+install command "install -Dm755 JobDocs /app/bin/JobDocs" and the JobDocs source
+entry) to treat JobDocs as a directory (either set the source type to dir or
+adjust build-commands to install the launcher and required runtime files from
+the staged directory), ensuring the manifest installs the launcher and its
+runtime files rather than expecting a single file.
+
+---
+
+Nitpick comments:
+In @.github/workflows/build-release.yml:
+- Around line 77-81: The "Build Windows installer" step calls the external tool
+"iscc" (iscc build_scripts\JobDocs.iss) without ensuring Inno Setup is
+available; add a guard that either installs Inno Setup (for example via
+Chocolatey) or asserts presence and fails fast: use a PowerShell check like
+Get-Command iscc -ErrorAction SilentlyContinue and if missing run choco install
+innosetup --confirm (or exit with a clear error), then proceed to set
+$env:RELEASE_VERSION and run iscc; update the step that currently contains "iscc
+build_scripts\JobDocs.iss" to include this installation/check sequence so the
+job no longer depends on the runner image having iscc preinstalled.
+```
+
+</details>
+
+<details>
+<summary>🪄 Autofix (Beta)</summary>
+
+Fix all unresolved CodeRabbit comments on this PR:
+
+- [ ] <!-- {"checkboxId": "4b0d0e0a-96d7-4f10-b296-3a18ea78f0b9"} --> Push a commit to this branch (recommended)
+- [ ] <!-- {"checkboxId": "ff5b1114-7d8c-49e6-8ac1-43f82af23a33"} --> Create a new PR with the fixes
+
+</details>
+
+---
+
+<details>
+<summary>ℹ️ Review info</summary>
+
+<details>
+<summary>⚙️ Run configuration</summary>
+
+**Configuration used**: Path: .coderabbit.yaml
+
+**Review profile**: CHILL
+
+**Plan**: Pro
+
+**Run ID**: `d0a64a06-ed6c-4265-887a-570dacc35f6d`
+
+</details>
+
+<details>
+<summary>📥 Commits</summary>
+
+Reviewing files that changed from the base of the PR and between b95329c957824238499eb46595b72a57b371122e and ef7acd1a69e0430d13f20002904ccbf975c80051.
+
+</details>
+
+<details>
+<summary>📒 Files selected for processing (3)</summary>
+
+* `.github/workflows/build-release.yml`
+* `build_scripts/JobDocs.iss`
+* `build_scripts/JobDocs.spec`
+
+</details>
+
+</details>
+
+<!-- This is an auto-generated comment by CodeRabbit for review status -->

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -3140,3 +3140,24 @@ Reviewing files that changed from the base of the PR and between b95329c95782423
 </details>
 
 <!-- This is an auto-generated comment by CodeRabbit for review status -->
+
+---
+
+## 2026-04-13 — `.github/workflows/build-release.yml` (onedir build + Inno Setup, PR #14)
+
+**Review:** Two findings from CodeRabbit on PR #14.
+**Result:** Both fixed before merge.
+
+### Findings
+
+1. **iscc invoked without asserting Inno Setup is on PATH**
+   - `iscc` called directly in the Build Windows installer step with no guard
+   - Added a prior step: `Get-Command iscc -ErrorAction SilentlyContinue` — installs via choco if missing
+   - Pattern: always guard external tools not installed by `pip install` or `apt-get`
+
+2. **Flatpak staging copied only the PyInstaller launcher, not the onedir runtime tree**
+   - `cp dist/JobDocs/JobDocs linux/flatpak/JobDocs` staged only the binary; onedir requires all `.so` files and data
+   - Fixed staging to `cp -r dist/JobDocs linux/flatpak/JobDocs_dir`
+   - Updated manifest source from `type: file` to `type: dir, path: JobDocs_dir`
+   - Updated build-commands: `cp -r . /app/lib/JobDocs/` + `ln -s /app/lib/JobDocs/JobDocs /app/bin/JobDocs`
+   - Pattern: when switching PyInstaller from onefile to onedir, update every downstream consumer of the binary path (Flatpak staging, manifest, verify steps)

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -74,6 +74,13 @@ jobs:
       #     github-artifact-name: JobDocs-unsigned
       #     output-artifact-name: JobDocs-signed
 
+      - name: Ensure Inno Setup is available
+        run: |
+          if (!(Get-Command iscc -ErrorAction SilentlyContinue)) {
+            choco install innosetup --confirm --no-progress
+          }
+        shell: pwsh
+
       - name: Build Windows installer
         run: |
           $env:RELEASE_VERSION = "${{ github.ref_name }}"
@@ -141,7 +148,7 @@ jobs:
 
       - name: Stage files for Flatpak manifest
         run: |
-          cp dist/JobDocs/JobDocs linux/flatpak/JobDocs
+          cp -r dist/JobDocs linux/flatpak/JobDocs_dir
           cp JobDocs.iconset/icon_256x256.png linux/flatpak/icon_256x256.png
 
       - name: Build Flatpak

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -24,7 +24,7 @@ jobs:
           echo "OK: $GITHUB_REF_NAME is descended from stable"
 
   # ---------------------------------------------------------------------------
-  # Windows — PyInstaller single-file EXE
+  # Windows — PyInstaller onedir build packaged by Inno Setup
   # ---------------------------------------------------------------------------
   build-windows:
     needs: verify-stable-ancestry
@@ -47,27 +47,21 @@ jobs:
           pip install "pyinstaller>=6.0.0" "Pillow>=10.4.0,<12.0.0"
 
       - name: Build executable
-        run: |
-          python -m PyInstaller --distpath build_dist --workpath build_temp build_scripts/JobDocs.spec
+        run: python -m PyInstaller build_scripts/JobDocs.spec --clean --noconfirm
 
       - name: Verify build
         run: |
-          if (!(Test-Path "build_dist/JobDocs.exe")) {
-            Write-Error "build_dist/JobDocs.exe not found — build failed"
+          if (!(Test-Path "dist/JobDocs/JobDocs.exe")) {
+            Write-Error "dist/JobDocs/JobDocs.exe not found — build failed"
             exit 1
           }
-          Write-Output "Build OK: $(Get-Item build_dist/JobDocs.exe | Select-Object -ExpandProperty Length) bytes"
-
-      - name: Upload unsigned artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: JobDocs-unsigned
-          path: build_dist/JobDocs.exe
+          Write-Output "Build OK: $(Get-Item dist/JobDocs/JobDocs.exe | Select-Object -ExpandProperty Length) bytes"
+        shell: pwsh
 
       # -----------------------------------------------------------------------
       # SignPath code signing — uncomment once SignPath Foundation is approved
       # Apply at: https://signpath.io/product/open-source
-      # After enabling: update the create-release step to use JobDocs-signed
+      # Sign dist/JobDocs/JobDocs.exe before iscc packages it.
       # -----------------------------------------------------------------------
       # - name: Sign executable
       #   uses: signpath/github-action-submit-signing-request@v1
@@ -80,11 +74,17 @@ jobs:
       #     github-artifact-name: JobDocs-unsigned
       #     output-artifact-name: JobDocs-signed
 
+      - name: Build Windows installer
+        run: |
+          $env:RELEASE_VERSION = "${{ github.ref_name }}"
+          iscc build_scripts\JobDocs.iss
+        shell: pwsh
+
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v4
         with:
           name: JobDocs-windows
-          path: build_dist/JobDocs.exe
+          path: installer_out/JobDocs-${{ github.ref_name }}-windows-setup.exe
 
   # ---------------------------------------------------------------------------
   # Linux — PyInstaller binary wrapped in a Flatpak bundle
@@ -110,13 +110,12 @@ jobs:
           pip install "pyinstaller>=6.0.0"
 
       - name: Build PyInstaller binary
-        run: |
-          python -m PyInstaller --distpath build_dist --workpath build_temp build_scripts/JobDocs.spec
+        run: python -m PyInstaller build_scripts/JobDocs.spec --clean --noconfirm
 
       - name: Verify binary
         run: |
-          test -f build_dist/JobDocs || { echo "build_dist/JobDocs not found — build failed"; exit 1; }
-          echo "Build OK: $(du -h build_dist/JobDocs | cut -f1)"
+          test -f dist/JobDocs/JobDocs || { echo "dist/JobDocs/JobDocs not found — build failed"; exit 1; }
+          echo "Build OK: $(du -h dist/JobDocs/JobDocs | cut -f1)"
 
       - name: Install Flatpak tools
         run: |
@@ -142,7 +141,7 @@ jobs:
 
       - name: Stage files for Flatpak manifest
         run: |
-          cp build_dist/JobDocs linux/flatpak/JobDocs
+          cp dist/JobDocs/JobDocs linux/flatpak/JobDocs
           cp JobDocs.iconset/icon_256x256.png linux/flatpak/icon_256x256.png
 
       - name: Build Flatpak
@@ -196,8 +195,8 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           name: JobDocs ${{ github.ref_name }}
-          files: release-assets/*
-          # When signing is enabled, re-download JobDocs-signed instead of
-          # JobDocs-windows above, and update files: accordingly.
+          files: |
+            release-assets/JobDocs-${{ github.ref_name }}-windows-setup.exe
+            release-assets/JobDocs-linux.flatpak
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/build_scripts/JobDocs.iss
+++ b/build_scripts/JobDocs.iss
@@ -1,0 +1,43 @@
+#define MyAppName "JobDocs"
+#define MyAppVersion GetEnv("RELEASE_VERSION")
+#define MyAppPublisher "i-machine-things"
+#define MyAppURL "https://github.com/i-machine-things/JobDocs"
+#define MyAppExeName "JobDocs.exe"
+#define MyAppId "{{B7C4D2A1-5E8F-4A9B-8C2D-3E4F5A6B7C8D}"
+
+[Setup]
+AppId={#MyAppId}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}
+AppUpdatesURL={#MyAppURL}
+DefaultDirName={autopf}\{#MyAppName}
+DefaultGroupName={#MyAppName}
+DisableProgramGroupPage=yes
+OutputDir=..\installer_out
+OutputBaseFilename=JobDocs-{#MyAppVersion}-windows-setup
+SetupIconFile=..\windows\icon.ico
+Compression=lzma2/max
+SolidCompression=yes
+WizardStyle=modern
+PrivilegesRequired=lowest
+PrivilegesRequiredOverridesAllowed=commandline
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
+
+[Files]
+Source: "..\dist\JobDocs\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; IconFilename: "{app}\{#MyAppExeName}"
+Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; IconFilename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent

--- a/build_scripts/JobDocs.spec
+++ b/build_scripts/JobDocs.spec
@@ -191,26 +191,34 @@ pyz = PYZ(
     cipher=None,
 )
 
-# EXE - main executable (single-file build)
+# EXE - launcher (onedir build — binaries/data go into COLLECT)
 exe = EXE(
     pyz,
     a.scripts,
-    a.binaries,
-    a.zipfiles,
-    a.datas,
-    [],
+    exclude_binaries=True,
     name=APP_NAME,
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
-    upx=True,  # Enable UPX compression to reduce size
+    upx=True,
     upx_exclude=[],
-    runtime_tmpdir=None,
-    console=False,  # Set to False for GUI application (no console window)
+    console=False,  # GUI application — no console window
     disable_windowed_traceback=False,
     argv_emulation=False,
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
     icon=ICON_FILE,
+)
+
+# COLLECT - gathers exe + all binaries/data into a single directory
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name=APP_NAME,
 )

--- a/linux/flatpak/io.github.i_machine_things.JobDocs.yml
+++ b/linux/flatpak/io.github.i_machine_things.JobDocs.yml
@@ -25,8 +25,9 @@ modules:
     # The PyInstaller binary and support files are staged into this directory
     # by the CI workflow before flatpak-builder is invoked.
     sources:
-      - type: file
-        path: JobDocs
+      # PyInstaller onedir tree — staged by CI as linux/flatpak/JobDocs_dir/
+      - type: dir
+        path: JobDocs_dir
       - type: file
         path: io.github.i_machine_things.JobDocs.desktop
       - type: file
@@ -34,8 +35,12 @@ modules:
       - type: file
         path: icon_256x256.png
     build-commands:
-      # Install the PyInstaller single-file binary
-      - install -Dm755 JobDocs /app/bin/JobDocs
+      # Install the PyInstaller onedir tree to /app/lib/JobDocs
+      - install -d /app/lib/JobDocs
+      - cp -r . /app/lib/JobDocs/
+      - chmod 755 /app/lib/JobDocs/JobDocs
+      # Symlink launcher into /app/bin so Flatpak command: JobDocs resolves it
+      - ln -s /app/lib/JobDocs/JobDocs /app/bin/JobDocs
       # Desktop entry
       - install -Dm644 io.github.i_machine_things.JobDocs.desktop
           /app/share/applications/io.github.i_machine_things.JobDocs.desktop


### PR DESCRIPTION
## Summary

- Switch PyInstaller spec from single-file to onedir (`COLLECT` step) — output lands in `dist/JobDocs/`
- Add `build_scripts/JobDocs.iss` (modelled on HoneyBatchr) — packages the onedir folder into `installer_out/JobDocs-{version}-windows-setup.exe`
- Update `build-release.yml`: run `iscc` after PyInstaller, upload the installer as the Windows release asset, fix Linux flatpak paths to match new `dist/JobDocs/` output

## Test plan

- [ ] Merge to stable and tag a release (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] Confirm `build-windows` job produces `dist/JobDocs/JobDocs.exe` and runs `iscc` without error
- [ ] Confirm `installer_out/JobDocs-vX.Y.Z-windows-setup.exe` is attached to the GitHub Release
- [ ] Run the installer locally: verify Start Menu shortcut, optional desktop icon, and clean uninstall
- [ ] Confirm `build-flatpak` job still passes with updated `dist/JobDocs/JobDocs` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Windows releases now distributed as an installer package instead of a standalone executable
  * Updated build and release artifact handling for Windows and Linux distributions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->