### PR TITLE
fix: create /app/bin before symlinking JobDocs launcher in Flatpak

### DIFF
--- a/linux/flatpak/io.github.i_machine_things.JobDocs.yml
+++ b/linux/flatpak/io.github.i_machine_things.JobDocs.yml
@@ -40,6 +40,7 @@ modules:
       - cp -r . /app/lib/JobDocs/
       - chmod 755 /app/lib/JobDocs/JobDocs
       # Symlink launcher into /app/bin so Flatpak command: JobDocs resolves it
+      - install -d /app/bin
       - ln -s /app/lib/JobDocs/JobDocs /app/bin/JobDocs
       # Desktop entry
       - install -Dm644 io.github.i_machine_things.JobDocs.desktop


### PR DESCRIPTION
## Summary
- Adds `install -d /app/bin` before the `ln -s` step in the Flatpak build-commands
- The `/app/bin` directory is not guaranteed to exist in the Flatpak sandbox at build time, causing `ln` to fail with *No such file or directory*

## Root cause
The v0.5.3 release build failed with:
```
ln: failed to create symbolic link '/app/bin/JobDocs': No such file or directory
Error: module JobDocs: Child process exited with code 1
```
`/app/lib/JobDocs` was created explicitly but `/app/bin` was assumed to pre-exist.

## Test plan
- [ ] Flatpak CI job passes on this branch
- [ ] `JobDocs-linux.flatpak` bundle produced as release asset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Flatpak build configuration issue that could prevent successful application deployment by ensuring proper directory structure creation during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->