### PR TITLE
feat: plugins directory with GitHub install support

### DIFF
--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -3441,3 +3441,110 @@ Reviewing files that changed from the base of the PR and between 06a003d32c95a0c
 </details>
 
 <!-- This is an auto-generated comment by CodeRabbit for review status -->
+
+---
+
+## 2026-04-14 — `PR #16: feat: plugins directory with GitHub install support` — review run 1
+
+**Actionable comments posted: 3**
+
+<details>
+<summary>🤖 Prompt for all review comments with AI agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+Inline comments:
+In `@core/settings_dialog.py`:
+- Around line 433-436: The current flow in settings_dialog.py blindly assumes
+self._save_callback({'plugins_dir': plugins_dir_str}) persisted the value;
+change the call-site in the code that sets self.settings['plugins_dir'] so it
+either catches an exception from the callback or checks a boolean success return
+(agree on one API), and if persistence failed (callback raised or returned
+False) abort before starting the plugin install/worker. Update the contract with
+the caller (main._partial_save_settings) so it either raises an IOError on
+failure or returns True/False, and in settings_dialog use that to stop the
+install worker when persistence did not succeed.
+- Around line 453-458: Disable all install-related controls when starting
+_PluginInstallWorker: besides calling self.github_install_btn.setEnabled(False),
+also disable self.plugins_dir_edit and any dialog action buttons (e.g.,
+Save/Cancel) or set a flag to block accept() and reject() while
+self._install_worker is active; re-enable those controls (or clear the blocking
+flag) in the _on_plugin_install_success and _on_plugin_install_error handlers
+where worker finishes, and ensure this same behavior is applied to the code
+paths around lines 460-474 that start the worker so the dialog cannot be
+edited/closed while installation is running.
+- Around line 90-103: The current swap removes the live plugin
+(shutil.rmtree(dest)) before ensuring the temp rename succeeded, which can leave
+no plugin if rename fails; change the sequence to perform an atomic replace of
+dest with the temp copy instead of deleting dest first: after
+shutil.copytree(src, tmp_dest) call tmp_dest.replace(dest) (or
+os.replace(tmp_dest, dest)) in place of tmp_dest.rename(dest), keep the existing
+exception handler to rmtree tmp_dest on failure, and remove the explicit
+shutil.rmtree(dest) call so the live plugin is only replaced when the atomic
+replace succeeds (refer to tmp_dest, dest, shutil.copytree, tmp_dest.rename in
+the diff).
+```
+
+</details>
+
+<details>
+<summary>🪄 Autofix (Beta)</summary>
+
+Fix all unresolved CodeRabbit comments on this PR:
+
+- [ ] <!-- {"checkboxId": "4b0d0e0a-96d7-4f10-b296-3a18ea78f0b9"} --> Push a commit to this branch (recommended)
+- [ ] <!-- {"checkboxId": "ff5b1114-7d8c-49e6-8ac1-43f82af23a33"} --> Create a new PR with the fixes
+
+</details>
+
+---
+
+<details>
+<summary>ℹ️ Review info</summary>
+
+<details>
+<summary>⚙️ Run configuration</summary>
+
+**Configuration used**: Path: .coderabbit.yaml
+
+**Review profile**: CHILL
+
+**Plan**: Pro
+
+**Run ID**: `4d2fe782-5341-4cf9-9edc-e4805c740200`
+
+</details>
+
+<details>
+<summary>📥 Commits</summary>
+
+Reviewing files that changed from the base of the PR and between 0f9227abe8f1912de8831fb40bf0f32344d05427 and d5791453f964a1cfe6c38cfec135570d649d6c5e.
+
+</details>
+
+<details>
+<summary>⛔ Files ignored due to path filters (1)</summary>
+
+* `.claude/S&P.md` is excluded by `!.claude/S&P.md`
+
+</details>
+
+<details>
+<summary>📒 Files selected for processing (2)</summary>
+
+* `core/settings_dialog.py`
+* `main.py`
+
+</details>
+
+<details>
+<summary>🚧 Files skipped from review as they are similar to previous changes (1)</summary>
+
+* main.py
+
+</details>
+
+</details>
+
+<!-- This is an auto-generated comment by CodeRabbit for review status -->

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -3161,3 +3161,113 @@ Reviewing files that changed from the base of the PR and between b95329c95782423
    - Updated manifest source from `type: file` to `type: dir, path: JobDocs_dir`
    - Updated build-commands: `cp -r . /app/lib/JobDocs/` + `ln -s /app/lib/JobDocs/JobDocs /app/bin/JobDocs`
    - Pattern: when switching PyInstaller from onefile to onedir, update every downstream consumer of the binary path (Flatpak staging, manifest, verify steps)
+
+---
+
+## 2026-04-13 — `PR #16: feat: plugins directory with GitHub install support` — review run 1
+
+**Actionable comments posted: 4**
+
+<details>
+<summary>🤖 Prompt for all review comments with AI agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+Inline comments:
+In `@core/module_loader.py`:
+- Around line 77-84: The plugin-directory scan currently calls
+self.plugins_dir.iterdir() and walks entries without handling
+OSError/PermissionError, so update the loops that scan self.plugins_dir (the
+block using iterdir() that appends to all_modules and sets
+self._plugin_module_dirs, and the similar block around the later scan) to wrap
+the directory iteration and per-item filesystem checks in try/except that
+catches OSError and PermissionError, logs the exception with context (including
+the plugin path and exception message) via the module logger, and
+continues—i.e., on exception skip that plugins_dir or item and do not abort
+discovery so built-in modules still load.
+- Around line 128-143: The plugin loader branch that handles external plugins
+(uses variables plugin_dir, module_path, spec, module and spec.loader) does not
+set package context so relative imports in plugin packages fail; fix by
+assigning spec.submodule_search_locations to the plugin package directory before
+exec_module and ensure the parent package (e.g. "plugins.<module_name>") is
+present in sys.modules with a ModuleType instance whose __path__ includes
+module_path.parent so relative imports (like from .helpers) resolve correctly;
+do this immediately after creating the spec (and before spec.loader.exec_module)
+and register both the package name and the full spec.name in sys.modules.
+
+In `@core/settings_dialog.py`:
+- Around line 333-339: The install flow uses the current textbox value
+(plugins_dir_edit.text()) but never persists it, so the application won't see
+the new plugins_dir on next startup; update the install handler(s) that use
+plugins_dir_str (the block around plugins_dir_edit/Text usage and the other
+occurrences referenced) to save the value to your persistent settings (e.g., via
+QSettings or the existing settings API) before proceeding with
+extraction/install, and/or refuse to treat the install as "restart-ready" until
+the in-memory textbox value matches the persisted value—i.e., call the settings
+write (e.g., setValue('plugins_dir', plugins_dir_str) or the project's
+equivalent) immediately after validating plugins_dir_str and before returning
+from the install routine.
+- Around line 363-425: The _install_github_plugin function is performing network
+and file I/O on the GUI thread; refactor it to run the download/extract/copy
+logic inside a background worker (QThread subclass or QRunnable used with
+QThreadPool) and only emit signals back to the dialog for UI updates. Move all
+calls to urllib.request.urlopen, resp.read(), zipfile.ZipFile.extractall,
+shutil.copytree, and any filesystem writes into the worker; have the worker emit
+success (module_name and dest path) and error signals (exception message) which
+the main thread connects to show QMessageBox.information/QMessageBox.critical,
+clear github_repo_edit and set installed flag, and ensure plugins_dir.mkdir is
+done in the worker or synchronized before showing success. Keep the UI handler
+(button click) lightweight: start the worker and disable the button until
+completion.
+```
+
+</details>
+
+<details>
+<summary>🪄 Autofix (Beta)</summary>
+
+Fix all unresolved CodeRabbit comments on this PR:
+
+- [ ] <!-- {"checkboxId": "4b0d0e0a-96d7-4f10-b296-3a18ea78f0b9"} --> Push a commit to this branch (recommended)
+- [ ] <!-- {"checkboxId": "ff5b1114-7d8c-49e6-8ac1-43f82af23a33"} --> Create a new PR with the fixes
+
+</details>
+
+---
+
+<details>
+<summary>ℹ️ Review info</summary>
+
+<details>
+<summary>⚙️ Run configuration</summary>
+
+**Configuration used**: Path: .coderabbit.yaml
+
+**Review profile**: CHILL
+
+**Plan**: Pro
+
+**Run ID**: `2ed3b398-fbbf-4985-828f-b87460e3b6a7`
+
+</details>
+
+<details>
+<summary>📥 Commits</summary>
+
+Reviewing files that changed from the base of the PR and between 6328c6b988dd687547fccc3a1e2b128722e62956 and 06a003d32c95a0c50b9a9bb35d8caaea47c91bc2.
+
+</details>
+
+<details>
+<summary>📒 Files selected for processing (3)</summary>
+
+* `core/module_loader.py`
+* `core/settings_dialog.py`
+* `main.py`
+
+</details>
+
+</details>
+
+<!-- This is an auto-generated comment by CodeRabbit for review status -->

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -3301,3 +3301,143 @@ Reviewing files that changed from the base of the PR and between 6328c6b988dd687
    - Extract into `_PluginInstallWorker(QThread)` with `success = pyqtSignal(str, str)` and `error = pyqtSignal(str)`
    - GUI handler disables the Install button, starts the worker, reconnects signals to `_on_plugin_install_success` / `_on_plugin_install_error` which re-enable the button and show dialogs
    - Add `import urllib.error` (explicit) and `from PyQt6.QtCore import QThread, pyqtSignal`
+
+---
+
+## 2026-04-13 — `PR #16: feat: plugins directory with GitHub install support` — review run 2
+
+**Actionable comments posted: 1**
+
+<details>
+<summary>♻️ Duplicate comments (1)</summary><blockquote>
+
+<details>
+<summary>core/settings_dialog.py (1)</summary><blockquote>
+
+`420-421`: _⚠️ Potential issue_ | _🟠 Major_
+
+**Persist `plugins_dir` through the real settings store here.**
+
+`self.settings` is only the dialog-local copy created in `__init__`, so this assignment is still lost if the user installs successfully and then closes with Cancel. The success path says “restart” even though next startup will still read the old persisted `plugins_dir`.
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In `@core/settings_dialog.py` around lines 420 - 421, The dialog currently assigns
+plugins_dir_str only to the dialog-local self.settings, which doesn't persist
+across app restarts; instead write the value into the application's persistent
+settings store (use the existing app/settings manager API used elsewhere in the
+codebase) rather than only self.settings, and also update self.settings to keep
+the dialog state in sync; locate the code around self.settings and the
+plugins_dir_str assignment in settings_dialog.py and replace the local-only
+assignment with a call to the global/persistent settings API (e.g., the
+project's settings manager set/save method) so the change survives closing with
+Cancel and the restart message is accurate.
+```
+
+</details>
+
+</blockquote></details>
+
+</blockquote></details>
+
+<details>
+<summary>🤖 Prompt for all review comments with AI agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+Inline comments:
+In `@core/settings_dialog.py`:
+- Around line 71-74: Currently the code deletes dest (plugins_dir / repo) before
+copying, which can lose a working plugin if copy fails; change the behavior in
+both places where dest is removed and replaced (the block handling dest =
+plugins_dir / repo and the analogous block at lines 88-91) to first copy
+src_root into a temporary sibling directory (e.g., dest.with_suffix('.tmp') or
+dest + '.tmp'), verify the copy succeeded, then atomically move/replace the temp
+into place using os.replace or shutil.move, and ensure you remove the temp on
+failure so the original dest remains untouched until the new copy is fully
+staged.
+
+---
+
+Duplicate comments:
+In `@core/settings_dialog.py`:
+- Around line 420-421: The dialog currently assigns plugins_dir_str only to the
+dialog-local self.settings, which doesn't persist across app restarts; instead
+write the value into the application's persistent settings store (use the
+existing app/settings manager API used elsewhere in the codebase) rather than
+only self.settings, and also update self.settings to keep the dialog state in
+sync; locate the code around self.settings and the plugins_dir_str assignment in
+settings_dialog.py and replace the local-only assignment with a call to the
+global/persistent settings API (e.g., the project's settings manager set/save
+method) so the change survives closing with Cancel and the restart message is
+accurate.
+```
+
+</details>
+
+<details>
+<summary>🪄 Autofix (Beta)</summary>
+
+Fix all unresolved CodeRabbit comments on this PR:
+
+- [ ] <!-- {"checkboxId": "4b0d0e0a-96d7-4f10-b296-3a18ea78f0b9"} --> Push a commit to this branch (recommended)
+- [ ] <!-- {"checkboxId": "ff5b1114-7d8c-49e6-8ac1-43f82af23a33"} --> Create a new PR with the fixes
+
+</details>
+
+---
+
+<details>
+<summary>ℹ️ Review info</summary>
+
+<details>
+<summary>⚙️ Run configuration</summary>
+
+**Configuration used**: Path: .coderabbit.yaml
+
+**Review profile**: CHILL
+
+**Plan**: Pro
+
+**Run ID**: `086ba464-38ba-4dc7-88f4-505dccfc2ed6`
+
+</details>
+
+<details>
+<summary>📥 Commits</summary>
+
+Reviewing files that changed from the base of the PR and between 06a003d32c95a0c50b9a9bb35d8caaea47c91bc2 and 0f9227abe8f1912de8831fb40bf0f32344d05427.
+
+</details>
+
+<details>
+<summary>⛔ Files ignored due to path filters (1)</summary>
+
+* `.claude/S&P.md` is excluded by `!.claude/S&P.md`
+
+</details>
+
+<details>
+<summary>📒 Files selected for processing (3)</summary>
+
+* `build_scripts/JobDocs.iss`
+* `core/module_loader.py`
+* `core/settings_dialog.py`
+
+</details>
+
+<details>
+<summary>✅ Files skipped from review due to trivial changes (1)</summary>
+
+* build_scripts/JobDocs.iss
+
+</details>
+
+</details>
+
+<!-- This is an auto-generated comment by CodeRabbit for review status -->

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -3548,3 +3548,245 @@ Reviewing files that changed from the base of the PR and between 0f9227abe8f1912
 </details>
 
 <!-- This is an auto-generated comment by CodeRabbit for review status -->
+
+---
+
+## 2026-04-14 — `PR #16: feat: plugins directory with GitHub install support` — review run 2
+
+
+
+<details>
+<summary>♻️ Duplicate comments (2)</summary><blockquote>
+
+<details>
+<summary>core/settings_dialog.py (2)</summary><blockquote>
+
+`97-99`: _⚠️ Potential issue_ | _🟠 Major_
+
+**Preserve the current plugin until the final swap succeeds.**
+
+Line 98 deletes the live plugin before Line 99 is guaranteed to succeed. If rename fails, users lose the working plugin.
+
+  
+
+<details>
+<summary>Proposed safer swap (with rollback)</summary>
+
+```diff
+                         tmp_dest = dest.with_name(dest.name + '.tmp')
++                        backup_dest = dest.with_name(dest.name + '.bak')
+                         try:
+                             if tmp_dest.exists():
+                                 shutil.rmtree(tmp_dest)
++                            if backup_dest.exists():
++                                shutil.rmtree(backup_dest, ignore_errors=True)
+                             shutil.copytree(src, tmp_dest)
+                             if dest.exists():
+-                                shutil.rmtree(dest)
++                                dest.rename(backup_dest)
+                             tmp_dest.rename(dest)
++                            if backup_dest.exists():
++                                shutil.rmtree(backup_dest, ignore_errors=True)
+                         except Exception:
++                            if tmp_dest.exists():
++                                shutil.rmtree(tmp_dest, ignore_errors=True)
++                            if backup_dest.exists() and not dest.exists():
++                                backup_dest.rename(dest)
+-                            if tmp_dest.exists():
+-                                shutil.rmtree(tmp_dest, ignore_errors=True)
+                             raise
+```
+</details>
+
+```shell
+#!/bin/bash
+# Verify current non-rollback swap flow in worker
+sed -n '90,110p' core/settings_dialog.py
+```
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In `@core/settings_dialog.py` around lines 97 - 99, The current swap deletes the
+live plugin via shutil.rmtree(dest) before tmp_dest.rename(dest) succeeds;
+change the flow to preserve/rollback by first renaming/moving the current dest
+to a backup name (e.g., dest_backup) instead of deleting it, then rename
+tmp_dest to dest, and on any failure of tmp_dest.rename(dest) attempt to restore
+by renaming dest_backup back to dest; only remove the backup after the new dest
+is successfully in place; update the logic around dest.exists(),
+shutil.rmtree(dest) and tmp_dest.rename(dest) accordingly and ensure exceptions
+during rename trigger the rollback rename of the backup.
+```
+
+</details>
+
+---
+
+`438-443`: _⚠️ Potential issue_ | _🟠 Major_
+
+**Block dialog edits/close while plugin install worker is running.**
+
+Only the Install button is disabled. Users can still Save/Cancel/close, which can race worker callbacks against disposed UI state.
+
+  
+
+<details>
+<summary>Proposed guard for in-flight install lifecycle</summary>
+
+```diff
+ class SettingsDialog(QDialog):
+@@
+     def __init__(self, settings: Dict[str, Any], parent=None, available_modules: List[tuple] = None,
+                  save_callback=None, plugins_dir: Path = None):
+@@
+         self._plugins_dir = plugins_dir
++        self._install_in_progress = False
+@@
+-        button_box = QDialogButtonBox(
++        self.button_box = QDialogButtonBox(
+             QDialogButtonBox.StandardButton.Save | QDialogButtonBox.StandardButton.Cancel
+         )
+-        button_box.accepted.connect(self.save)
+-        button_box.rejected.connect(self.reject)
+-        main_layout.addWidget(button_box)
++        self.button_box.accepted.connect(self.save)
++        self.button_box.rejected.connect(self.reject)
++        main_layout.addWidget(self.button_box)
+@@
+         self.github_install_btn.setEnabled(False)
++        self._install_in_progress = True
++        self.github_repo_edit.setEnabled(False)
++        self.button_box.setEnabled(False)
+         worker = _PluginInstallWorker(owner, repo, self._plugins_dir)
+@@
+         self.github_install_btn.setEnabled(True)
++        self._install_in_progress = False
++        self.github_repo_edit.setEnabled(True)
++        self.button_box.setEnabled(True)
+@@
+         self.github_install_btn.setEnabled(True)
++        self._install_in_progress = False
++        self.github_repo_edit.setEnabled(True)
++        self.button_box.setEnabled(True)
+         QMessageBox.critical(self, "Install Plugin", message)
+         worker.deleteLater()
++
++    def reject(self):
++        if self._install_in_progress:
++            QMessageBox.information(self, "Install Plugin", "Please wait for install to finish.")
++            return
++        super().reject()
+```
+</details>
+
+```shell
+#!/bin/bash
+# Verify install-state handling and whether Save/Cancel/close are guarded
+rg -n -C2 "github_install_btn.setEnabled|button_box|def reject|_install_in_progress|worker.start" core/settings_dialog.py
+```
+
+
+Also applies to: 445-459
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In `@core/settings_dialog.py` around lines 438 - 443, The dialog allows
+Save/Cancel/close while a plugin install worker (created in the block that sets
+self.github_install_btn and self._install_worker and starts worker) is running,
+which can race with callbacks
+(_on_plugin_install_success/_on_plugin_install_error) against a disposed UI; add
+an in-flight guard: introduce a boolean like self._install_in_progress set True
+before worker.start() and False in both _on_plugin_install_success and
+_on_plugin_install_error, disable the dialog buttons (e.g. the button box, and
+block reject/accept/close) while _install_in_progress is True, and make
+reject/accept early-return when the flag is set so callbacks won't touch
+disposed widgets.
+```
+
+</details>
+
+</blockquote></details>
+
+</blockquote></details>
+
+<details>
+<summary>🤖 Prompt for all review comments with AI agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+Duplicate comments:
+In `@core/settings_dialog.py`:
+- Around line 97-99: The current swap deletes the live plugin via
+shutil.rmtree(dest) before tmp_dest.rename(dest) succeeds; change the flow to
+preserve/rollback by first renaming/moving the current dest to a backup name
+(e.g., dest_backup) instead of deleting it, then rename tmp_dest to dest, and on
+any failure of tmp_dest.rename(dest) attempt to restore by renaming dest_backup
+back to dest; only remove the backup after the new dest is successfully in
+place; update the logic around dest.exists(), shutil.rmtree(dest) and
+tmp_dest.rename(dest) accordingly and ensure exceptions during rename trigger
+the rollback rename of the backup.
+- Around line 438-443: The dialog allows Save/Cancel/close while a plugin
+install worker (created in the block that sets self.github_install_btn and
+self._install_worker and starts worker) is running, which can race with
+callbacks (_on_plugin_install_success/_on_plugin_install_error) against a
+disposed UI; add an in-flight guard: introduce a boolean like
+self._install_in_progress set True before worker.start() and False in both
+_on_plugin_install_success and _on_plugin_install_error, disable the dialog
+buttons (e.g. the button box, and block reject/accept/close) while
+_install_in_progress is True, and make reject/accept early-return when the flag
+is set so callbacks won't touch disposed widgets.
+```
+
+</details>
+
+---
+
+<details>
+<summary>ℹ️ Review info</summary>
+
+<details>
+<summary>⚙️ Run configuration</summary>
+
+**Configuration used**: Path: .coderabbit.yaml
+
+**Review profile**: CHILL
+
+**Plan**: Pro
+
+**Run ID**: `33c76dda-ae89-418c-b244-735b3c652f87`
+
+</details>
+
+<details>
+<summary>📥 Commits</summary>
+
+Reviewing files that changed from the base of the PR and between d5791453f964a1cfe6c38cfec135570d649d6c5e and 0890df4e3d4e0cc3ea16cffff2bf9eb28ff18f29.
+
+</details>
+
+<details>
+<summary>⛔ Files ignored due to path filters (1)</summary>
+
+* `.claude/S&P.md` is excluded by `!.claude/S&P.md`
+
+</details>
+
+<details>
+<summary>📒 Files selected for processing (2)</summary>
+
+* `core/settings_dialog.py`
+* `main.py`
+
+</details>
+
+</details>
+
+<!-- This is an auto-generated comment by CodeRabbit for review status -->

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -3271,3 +3271,33 @@ Reviewing files that changed from the base of the PR and between 6328c6b988dd687
 </details>
 
 <!-- This is an auto-generated comment by CodeRabbit for review status -->
+
+---
+
+## 2026-04-13 — `core/module_loader.py`, `core/settings_dialog.py` (PR #16 CR resolutions)
+
+**Review:** 4 actionable findings from CodeRabbit on PR #16 (plugins directory feature)
+**Result:** All 4 findings fixed in commits `fd8b1fa` and `e4b8e2e`
+
+### Findings
+
+1. **Wrap plugin dir scans in OSError/PermissionError handlers** (`module_loader.py`)
+   - Both frozen and dev-mode `iterdir()` loops must catch `OSError`/`PermissionError` per item and per directory
+   - Log with context via `logger.warning(...)` and continue — never abort built-in module discovery
+   - Add `import logging` and `logger = logging.getLogger(__name__)` at module level
+
+2. **Register parent package before exec_module for relative imports** (`module_loader.py`)
+   - External plugins that use `from .helpers import ...` fail because no parent package is in `sys.modules`
+   - Before creating the spec, register `plugins.<module_name>` as a `types.ModuleType` with `__path__` set to the plugin dir
+   - Pass `submodule_search_locations=[str(module_path.parent)]` to `spec_from_file_location`
+   - Add `import types` at module level
+
+3. **Persist plugins_dir before install, not only on Save** (`settings_dialog.py`)
+   - `_install_github_plugin` reads `plugins_dir_edit.text()` but never writes to `self.settings`
+   - Add `self.settings['plugins_dir'] = plugins_dir_str` immediately after validation so the value survives dialog close without Save
+
+4. **Move download/extract to background QThread** (`settings_dialog.py`)
+   - `urllib.request.urlopen`, `resp.read()`, `zipfile.ZipFile`, `shutil.copytree` all ran on the GUI thread — freezes the UI
+   - Extract into `_PluginInstallWorker(QThread)` with `success = pyqtSignal(str, str)` and `error = pyqtSignal(str)`
+   - GUI handler disables the Install button, starts the worker, reconnects signals to `_on_plugin_install_success` / `_on_plugin_install_error` which re-enable the button and show dialogs
+   - Add `import urllib.error` (explicit) and `from PyQt6.QtCore import QThread, pyqtSignal`

--- a/build_scripts/JobDocs.iss
+++ b/build_scripts/JobDocs.iss
@@ -31,6 +31,9 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
 
+[Dirs]
+Name: "{app}\plugins"; Flags: uninsneveruninstall
+
 [Files]
 Source: "..\dist\JobDocs\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 

--- a/core/module_loader.py
+++ b/core/module_loader.py
@@ -22,18 +22,27 @@ class ModuleLoader:
     Modules are discovered by scanning the modules/ directory for
     subdirectories containing a module.py file with a class that
     inherits from BaseModule.
+
+    An optional plugins_dir can be provided. Any module folder placed there
+    is loaded from the filesystem at runtime (works in both dev and frozen/exe
+    mode) so external plugins do not need to be bundled into the executable.
     """
 
-    def __init__(self, modules_dir: Path):
+    def __init__(self, modules_dir: Path, plugins_dir: Path = None):
         """
         Initialize the module loader.
 
         Args:
-            modules_dir: Path to the modules directory
+            modules_dir: Path to the built-in modules directory
+            plugins_dir: Optional directory to scan for external plugin modules
         """
         self.modules_dir = modules_dir
+        self.plugins_dir = plugins_dir
         self.loaded_modules: List[BaseModule] = []
         self._module_classes: Dict[str, Type[BaseModule]] = {}
+        # Tracks which directory each module was found in (plugins_dir entries
+        # are always loaded from the filesystem, even in a frozen exe).
+        self._plugin_module_dirs: Dict[str, Path] = {}
 
     def discover_modules(self) -> List[str]:
         """
@@ -49,9 +58,8 @@ class ModuleLoader:
         deprecated_modules = {'add_to_job'}
 
         if is_frozen:
-            # In frozen mode, return hardcoded list of modules.
+            # In frozen mode, start with the hardcoded list of built-in modules.
             # Must match the modules in the spec file's hiddenimports.
-            # PSM-only modules (reporting) excluded from stable builds per .claude/CLAUDE.md Rule 3.
             # Keep this list in sync with hiddenimports in build_scripts/JobDocs.spec.
             all_modules = [
                 'quote',
@@ -62,21 +70,41 @@ class ModuleLoader:
                 'import_bp',
                 'history',
             ]
+            self._plugin_module_dirs.clear()
+
+            # Scan plugins_dir for external modules. These are loaded from the
+            # filesystem so users can drop a plugin folder in without rebuilding the exe.
+            if self.plugins_dir and self.plugins_dir.exists():
+                for item in self.plugins_dir.iterdir():
+                    if (item.is_dir() and not item.name.startswith('_')
+                            and item.name not in deprecated_modules
+                            and item.name not in all_modules):
+                        if (item / 'module.py').exists():
+                            all_modules.append(item.name)
+                            self._plugin_module_dirs[item.name] = self.plugins_dir
+
             return [m for m in all_modules if m not in deprecated_modules]
         else:
             # In development mode, discover from filesystem
-            if not self.modules_dir.exists():
-                return []
-
+            self._plugin_module_dirs.clear()
             module_names = []
-            for item in self.modules_dir.iterdir():
-                if item.is_dir() and not item.name.startswith('_'):
-                    # Skip deprecated modules
-                    if item.name in deprecated_modules:
-                        continue
-                    module_file = item / 'module.py'
-                    if module_file.exists():
-                        module_names.append(item.name)
+
+            scan_dirs = [self.modules_dir]
+            if self.plugins_dir and self.plugins_dir.exists():
+                scan_dirs.append(self.plugins_dir)
+
+            for scan_dir in scan_dirs:
+                if not scan_dir.exists():
+                    continue
+                for item in scan_dir.iterdir():
+                    if item.is_dir() and not item.name.startswith('_'):
+                        if item.name in deprecated_modules:
+                            continue
+                        module_file = item / 'module.py'
+                        if module_file.exists() and item.name not in module_names:
+                            module_names.append(item.name)
+                            if scan_dir is not self.modules_dir:
+                                self._plugin_module_dirs[item.name] = scan_dir
 
             return module_names
 
@@ -94,31 +122,42 @@ class ModuleLoader:
             ImportError: If module cannot be loaded
             ValueError: If module doesn't contain a valid BaseModule subclass
         """
-        # Check if running in a PyInstaller frozen environment
         is_frozen = getattr(sys, 'frozen', False)
+        plugin_dir = self._plugin_module_dirs.get(module_name)
 
-        if is_frozen:
-            # In frozen mode, use standard import (modules are bundled in executable)
+        if plugin_dir is not None:
+            # External plugin — always load from the filesystem (works in both
+            # dev and frozen/exe mode; plugin .py files are not bundled in the exe).
+            module_path = plugin_dir / module_name / 'module.py'
+            if not module_path.exists():
+                raise ImportError(f"Plugin module file not found: {module_path}")
+            spec = importlib.util.spec_from_file_location(
+                f"plugins.{module_name}.module",
+                module_path
+            )
+            if spec is None or spec.loader is None:
+                raise ImportError(f"Could not load plugin spec for {module_name}")
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[spec.name] = module
+            spec.loader.exec_module(module)
+        elif is_frozen:
+            # Built-in frozen module — use standard import (bundled in executable)
             module_import_name = f"modules.{module_name}.module"
             try:
                 module = importlib.import_module(module_import_name)
             except ImportError as e:
                 raise ImportError(f"Could not import frozen module {module_import_name}: {e}")
         else:
-            # In development mode, load from file path
+            # Development mode — load from file path
             module_path = self.modules_dir / module_name / 'module.py'
-
             if not module_path.exists():
                 raise ImportError(f"Module file not found: {module_path}")
-
-            # Load the module
             spec = importlib.util.spec_from_file_location(
                 f"modules.{module_name}.module",
                 module_path
             )
             if spec is None or spec.loader is None:
                 raise ImportError(f"Could not load module spec for {module_name}")
-
             module = importlib.util.module_from_spec(spec)
             sys.modules[spec.name] = module
             spec.loader.exec_module(module)
@@ -175,8 +214,11 @@ class ModuleLoader:
                 module_class = self.load_module(module_name)
                 instance = module_class()
 
-                # Skip experimental modules if not enabled
-                if instance.is_experimental() and not experimental_enabled:
+                # Skip experimental modules if not enabled.
+                # External plugins (in plugins_dir) bypass this — the user opted
+                # in by placing them there.
+                is_external_plugin = module_name in self._plugin_module_dirs
+                if instance.is_experimental() and not experimental_enabled and not is_external_plugin:
                     app_context.log_message(
                         f"Skipping experimental module: {module_name}"
                     )

--- a/core/module_loader.py
+++ b/core/module_loader.py
@@ -7,9 +7,13 @@ validates them, and provides them to the main application.
 
 import importlib
 import importlib.util
+import logging
+import types
 from pathlib import Path
 from typing import List, Dict, Any, Type
 import sys
+
+logger = logging.getLogger(__name__)
 
 from core.base_module import BaseModule
 from core.app_context import AppContext
@@ -75,13 +79,21 @@ class ModuleLoader:
             # Scan plugins_dir for external modules. These are loaded from the
             # filesystem so users can drop a plugin folder in without rebuilding the exe.
             if self.plugins_dir and self.plugins_dir.exists():
-                for item in self.plugins_dir.iterdir():
-                    if (item.is_dir() and not item.name.startswith('_')
-                            and item.name not in deprecated_modules
-                            and item.name not in all_modules):
-                        if (item / 'module.py').exists():
-                            all_modules.append(item.name)
-                            self._plugin_module_dirs[item.name] = self.plugins_dir
+                try:
+                    for item in self.plugins_dir.iterdir():
+                        try:
+                            if (item.is_dir() and not item.name.startswith('_')
+                                    and item.name not in deprecated_modules
+                                    and item.name not in all_modules):
+                                if (item / 'module.py').exists():
+                                    all_modules.append(item.name)
+                                    self._plugin_module_dirs[item.name] = self.plugins_dir
+                        except (OSError, PermissionError) as e:
+                            logger.warning("Skipping plugin item %s: %s", item, e)
+                except (OSError, PermissionError) as e:
+                    logger.warning(
+                        "Could not scan plugins directory %s: %s", self.plugins_dir, e
+                    )
 
             return [m for m in all_modules if m not in deprecated_modules]
         else:
@@ -96,15 +108,21 @@ class ModuleLoader:
             for scan_dir in scan_dirs:
                 if not scan_dir.exists():
                     continue
-                for item in scan_dir.iterdir():
-                    if item.is_dir() and not item.name.startswith('_'):
-                        if item.name in deprecated_modules:
-                            continue
-                        module_file = item / 'module.py'
-                        if module_file.exists() and item.name not in module_names:
-                            module_names.append(item.name)
-                            if scan_dir is not self.modules_dir:
-                                self._plugin_module_dirs[item.name] = scan_dir
+                try:
+                    for item in scan_dir.iterdir():
+                        try:
+                            if item.is_dir() and not item.name.startswith('_'):
+                                if item.name in deprecated_modules:
+                                    continue
+                                module_file = item / 'module.py'
+                                if module_file.exists() and item.name not in module_names:
+                                    module_names.append(item.name)
+                                    if scan_dir is not self.modules_dir:
+                                        self._plugin_module_dirs[item.name] = scan_dir
+                        except (OSError, PermissionError) as e:
+                            logger.warning("Skipping module item %s: %s", item, e)
+                except (OSError, PermissionError) as e:
+                    logger.warning("Could not scan directory %s: %s", scan_dir, e)
 
             return module_names
 
@@ -131,9 +149,20 @@ class ModuleLoader:
             module_path = plugin_dir / module_name / 'module.py'
             if not module_path.exists():
                 raise ImportError(f"Plugin module file not found: {module_path}")
+
+            # Register a parent package entry so relative imports (e.g. `from .helpers`)
+            # inside the plugin resolve correctly.
+            package_name = f"plugins.{module_name}"
+            if package_name not in sys.modules:
+                pkg = types.ModuleType(package_name)
+                pkg.__path__ = [str(module_path.parent)]
+                pkg.__package__ = package_name
+                sys.modules[package_name] = pkg
+
             spec = importlib.util.spec_from_file_location(
                 f"plugins.{module_name}.module",
-                module_path
+                module_path,
+                submodule_search_locations=[str(module_path.parent)],
             )
             if spec is None or spec.loader is None:
                 raise ImportError(f"Could not load plugin spec for {module_name}")

--- a/core/settings_dialog.py
+++ b/core/settings_dialog.py
@@ -12,10 +12,13 @@ Provides a UI for configuring application settings including:
 import io
 import shutil
 import tempfile
+import urllib.error
 import urllib.request
 import zipfile
+from pathlib import Path
 from typing import Dict, Any, List
 
+from PyQt6.QtCore import QThread, pyqtSignal
 from PyQt6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QGridLayout,
     QGroupBox, QLabel, QLineEdit, QPushButton, QCheckBox,
@@ -25,6 +28,82 @@ from PyQt6.QtWidgets import (
 )
 
 from shared.utils import get_os_type, get_os_text
+
+
+class _PluginInstallWorker(QThread):
+    """Background worker that downloads and extracts a GitHub plugin."""
+
+    success = pyqtSignal(str, str)  # module_name, dest_path
+    error = pyqtSignal(str)         # error message
+
+    def __init__(self, owner: str, repo: str, plugins_dir: Path):
+        super().__init__()
+        self._owner = owner
+        self._repo = repo
+        self._plugins_dir = plugins_dir
+
+    def run(self):
+        owner, repo = self._owner, self._repo
+        plugins_dir = self._plugins_dir
+        plugins_dir.mkdir(parents=True, exist_ok=True)
+
+        last_error = None
+        for branch in ('main', 'master'):
+            zip_url = f"https://github.com/{owner}/{repo}/archive/refs/heads/{branch}.zip"
+            try:
+                with urllib.request.urlopen(zip_url, timeout=30) as resp:
+                    zip_data = resp.read()
+
+                with zipfile.ZipFile(io.BytesIO(zip_data)) as zf:
+                    top_dirs = {n.split('/')[0] for n in zf.namelist() if '/' in n}
+                    if len(top_dirs) != 1:
+                        self.error.emit(
+                            "Unexpected ZIP structure — could not determine module root."
+                        )
+                        return
+                    zip_root = top_dirs.pop()
+
+                    with tempfile.TemporaryDirectory() as tmp:
+                        zf.extractall(tmp)
+                        src_root = Path(tmp) / zip_root
+
+                        if (src_root / 'module.py').exists():
+                            dest = plugins_dir / repo
+                            if dest.exists():
+                                shutil.rmtree(dest)
+                            shutil.copytree(src_root, dest)
+                            module_name = repo
+                        else:
+                            candidates = [
+                                d for d in src_root.iterdir()
+                                if d.is_dir() and (d / 'module.py').exists()
+                            ]
+                            if not candidates:
+                                self.error.emit(
+                                    f"No module.py found in {owner}/{repo}. "
+                                    "Ensure the repo contains a JobDocs plugin module."
+                                )
+                                return
+                            module_folder = candidates[0]
+                            dest = plugins_dir / module_folder.name
+                            if dest.exists():
+                                shutil.rmtree(dest)
+                            shutil.copytree(module_folder, dest)
+                            module_name = module_folder.name
+
+                self.success.emit(module_name, str(dest))
+                return
+
+            except urllib.error.HTTPError as e:
+                last_error = str(e)
+                continue
+            except Exception as e:
+                self.error.emit(f"Download failed:\n{e}")
+                return
+
+        self.error.emit(
+            f"Could not download {owner}/{repo} (tried main and master branches).\n{last_error}"
+        )
 
 
 class SettingsDialog(QDialog):
@@ -116,9 +195,9 @@ class SettingsDialog(QDialog):
         self.github_repo_edit = QLineEdit()
         self.github_repo_edit.setPlaceholderText("owner/repo  or  https://github.com/owner/repo")
         plugins_layout.addWidget(self.github_repo_edit, 2, 1)
-        github_install_btn = QPushButton("Install")
-        github_install_btn.clicked.connect(self._install_github_plugin)
-        plugins_layout.addWidget(github_install_btn, 2, 2)
+        self.github_install_btn = QPushButton("Install")
+        self.github_install_btn.clicked.connect(self._install_github_plugin)
+        plugins_layout.addWidget(self.github_install_btn, 2, 2)
 
         scroll_layout.addWidget(plugins_group)
 
@@ -324,7 +403,7 @@ class SettingsDialog(QDialog):
         main_layout.addWidget(button_box)
 
     def _install_github_plugin(self):
-        """Download a plugin from GitHub and extract it into the plugins directory."""
+        """Start a background download of a GitHub plugin into the plugins directory."""
         repo_input = self.github_repo_edit.text().strip()
         if not repo_input:
             QMessageBox.warning(self, "Install Plugin", "Enter a GitHub repo (owner/repo or full URL).")
@@ -338,8 +417,8 @@ class SettingsDialog(QDialog):
             )
             return
 
-        from pathlib import Path
-        plugins_dir = Path(plugins_dir_str)
+        # Persist immediately so the value survives if the dialog is closed without Save.
+        self.settings['plugins_dir'] = plugins_dir_str
 
         # Normalise input to owner/repo
         repo_input = repo_input.rstrip('/')
@@ -350,86 +429,34 @@ class SettingsDialog(QDialog):
         else:
             repo_slug = repo_input
 
-        # Strip any trailing path segments beyond owner/repo
         parts = repo_slug.split('/')
         if len(parts) < 2:
             QMessageBox.warning(self, "Install Plugin", f"Could not parse repo from: {repo_input}")
             return
         owner, repo = parts[0], parts[1]
 
-        # Try main then master branch
-        installed = False
-        last_error = None
-        for branch in ('main', 'master'):
-            zip_url = f"https://github.com/{owner}/{repo}/archive/refs/heads/{branch}.zip"
-            try:
-                with urllib.request.urlopen(zip_url, timeout=30) as resp:
-                    zip_data = resp.read()
+        self.github_install_btn.setEnabled(False)
+        worker = _PluginInstallWorker(owner, repo, Path(plugins_dir_str))
+        worker.success.connect(lambda name, dest: self._on_plugin_install_success(name, dest, worker))
+        worker.error.connect(lambda msg: self._on_plugin_install_error(msg, worker))
+        self._install_worker = worker  # prevent GC while running
+        worker.start()
 
-                with zipfile.ZipFile(io.BytesIO(zip_data)) as zf:
-                    # The ZIP contains a top-level folder like repo-main/
-                    top_dirs = {n.split('/')[0] for n in zf.namelist() if '/' in n}
-                    if len(top_dirs) != 1:
-                        QMessageBox.warning(
-                            self, "Install Plugin",
-                            "Unexpected ZIP structure — could not determine module root."
-                        )
-                        return
-                    zip_root = top_dirs.pop()
+    def _on_plugin_install_success(self, module_name: str, dest: str, worker: '_PluginInstallWorker'):
+        """Called on the main thread when a plugin install completes successfully."""
+        self.github_install_btn.setEnabled(True)
+        QMessageBox.information(
+            self, "Plugin Installed",
+            f"Plugin '{module_name}' installed to:\n{dest}\n\nRestart JobDocs to load it."
+        )
+        self.github_repo_edit.clear()
+        worker.deleteLater()
 
-                    # Extract to a temp dir, then move the contents into plugins_dir
-                    with tempfile.TemporaryDirectory() as tmp:
-                        zf.extractall(tmp)
-                        src_root = Path(tmp) / zip_root
-
-                        # If the extracted folder itself contains module.py it IS the module;
-                        # otherwise look one level deeper for a folder with module.py.
-                        if (src_root / 'module.py').exists():
-                            dest = plugins_dir / repo
-                            if dest.exists():
-                                shutil.rmtree(dest)
-                            shutil.copytree(src_root, dest)
-                            module_name = repo
-                        else:
-                            candidates = [
-                                d for d in src_root.iterdir()
-                                if d.is_dir() and (d / 'module.py').exists()
-                            ]
-                            if not candidates:
-                                QMessageBox.warning(
-                                    self, "Install Plugin",
-                                    f"No module.py found in {owner}/{repo}. "
-                                    "Ensure the repo contains a JobDocs plugin module."
-                                )
-                                return
-                            module_folder = candidates[0]
-                            dest = plugins_dir / module_folder.name
-                            if dest.exists():
-                                shutil.rmtree(dest)
-                            shutil.copytree(module_folder, dest)
-                            module_name = module_folder.name
-
-                plugins_dir.mkdir(parents=True, exist_ok=True)
-                QMessageBox.information(
-                    self, "Plugin Installed",
-                    f"Plugin '{module_name}' installed to:\n{dest}\n\nRestart JobDocs to load it."
-                )
-                self.github_repo_edit.clear()
-                installed = True
-                break
-
-            except urllib.error.HTTPError as e:
-                last_error = str(e)
-                continue
-            except Exception as e:
-                QMessageBox.critical(self, "Install Plugin", f"Download failed:\n{e}")
-                return
-
-        if not installed:
-            QMessageBox.critical(
-                self, "Install Plugin",
-                f"Could not download {owner}/{repo} (tried main and master branches).\n{last_error}"
-            )
+    def _on_plugin_install_error(self, message: str, worker: '_PluginInstallWorker'):
+        """Called on the main thread when a plugin install fails."""
+        self.github_install_btn.setEnabled(True)
+        QMessageBox.critical(self, "Install Plugin", message)
+        worker.deleteLater()
 
     def browse_dir(self, line_edit: QLineEdit):
         dir_path = QFileDialog.getExistingDirectory(self, "Select Directory")

--- a/core/settings_dialog.py
+++ b/core/settings_dialog.py
@@ -69,10 +69,8 @@ class _PluginInstallWorker(QThread):
 
                         if (src_root / 'module.py').exists():
                             dest = plugins_dir / repo
-                            if dest.exists():
-                                shutil.rmtree(dest)
-                            shutil.copytree(src_root, dest)
                             module_name = repo
+                            src = src_root
                         else:
                             candidates = [
                                 d for d in src_root.iterdir()
@@ -86,10 +84,23 @@ class _PluginInstallWorker(QThread):
                                 return
                             module_folder = candidates[0]
                             dest = plugins_dir / module_folder.name
+                            module_name = module_folder.name
+                            src = module_folder
+
+                        # Atomic swap: copy to a temp sibling, then replace.
+                        # Keeps the old plugin intact if the copy fails.
+                        tmp_dest = dest.with_name(dest.name + '.tmp')
+                        try:
+                            if tmp_dest.exists():
+                                shutil.rmtree(tmp_dest)
+                            shutil.copytree(src, tmp_dest)
                             if dest.exists():
                                 shutil.rmtree(dest)
-                            shutil.copytree(module_folder, dest)
-                            module_name = module_folder.name
+                            tmp_dest.rename(dest)
+                        except Exception:
+                            if tmp_dest.exists():
+                                shutil.rmtree(tmp_dest, ignore_errors=True)
+                            raise
 
                 self.success.emit(module_name, str(dest))
                 return
@@ -109,11 +120,13 @@ class _PluginInstallWorker(QThread):
 class SettingsDialog(QDialog):
     """Settings dialog"""
 
-    def __init__(self, settings: Dict[str, Any], parent=None, available_modules: List[tuple] = None):
+    def __init__(self, settings: Dict[str, Any], parent=None, available_modules: List[tuple] = None,
+                 save_callback=None):
         super().__init__(parent)
         self.settings = settings.copy()
         self.available_modules = available_modules or []  # List of (module_name, display_name) tuples
         self.module_checkboxes = {}  # Store module checkboxes
+        self._save_callback = save_callback  # Called to persist settings to disk mid-dialog
         self.setWindowTitle("Settings")
         self.setMinimumWidth(600)
         self.setup_ui()
@@ -419,6 +432,8 @@ class SettingsDialog(QDialog):
 
         # Persist immediately so the value survives if the dialog is closed without Save.
         self.settings['plugins_dir'] = plugins_dir_str
+        if self._save_callback:
+            self._save_callback({'plugins_dir': plugins_dir_str})
 
         # Normalise input to owner/repo
         repo_input = repo_input.rstrip('/')

--- a/core/settings_dialog.py
+++ b/core/settings_dialog.py
@@ -9,7 +9,13 @@ Provides a UI for configuring application settings including:
 - Experimental features
 """
 
+import io
+import shutil
+import tempfile
+import urllib.request
+import zipfile
 from typing import Dict, Any, List
+
 from PyQt6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QGridLayout,
     QGroupBox, QLabel, QLineEdit, QPushButton, QCheckBox,
@@ -87,6 +93,34 @@ class SettingsDialog(QDialog):
         itar_layout.addWidget(itar_cf_btn, 1, 2)
 
         scroll_layout.addWidget(itar_group)
+
+        # Plugins directory group
+        plugins_group = QGroupBox("Plugins Directory (optional)")
+        plugins_layout = QGridLayout(plugins_group)
+
+        plugins_layout.addWidget(QLabel("Plugins Directory:"), 0, 0)
+        self.plugins_dir_edit = QLineEdit(self.settings.get('plugins_dir', ''))
+        self.plugins_dir_edit.setPlaceholderText("Folder containing external plugin modules")
+        plugins_layout.addWidget(self.plugins_dir_edit, 0, 1)
+        plugins_btn = QPushButton("Browse...")
+        plugins_btn.clicked.connect(lambda: self.browse_dir(self.plugins_dir_edit))
+        plugins_layout.addWidget(plugins_btn, 0, 2)
+
+        plugins_info = QLabel("Drop a plugin module folder here to load it at startup (requires restart)")
+        plugins_info.setWordWrap(True)
+        plugins_info.setStyleSheet("color: gray; font-size: 9pt;")
+        plugins_layout.addWidget(plugins_info, 1, 0, 1, 3)
+
+        # GitHub install row
+        plugins_layout.addWidget(QLabel("Install from GitHub:"), 2, 0)
+        self.github_repo_edit = QLineEdit()
+        self.github_repo_edit.setPlaceholderText("owner/repo  or  https://github.com/owner/repo")
+        plugins_layout.addWidget(self.github_repo_edit, 2, 1)
+        github_install_btn = QPushButton("Install")
+        github_install_btn.clicked.connect(self._install_github_plugin)
+        plugins_layout.addWidget(github_install_btn, 2, 2)
+
+        scroll_layout.addWidget(plugins_group)
 
         # Link type group
         link_group = QGroupBox("Link Type")
@@ -289,6 +323,114 @@ class SettingsDialog(QDialog):
         button_box.rejected.connect(self.reject)
         main_layout.addWidget(button_box)
 
+    def _install_github_plugin(self):
+        """Download a plugin from GitHub and extract it into the plugins directory."""
+        repo_input = self.github_repo_edit.text().strip()
+        if not repo_input:
+            QMessageBox.warning(self, "Install Plugin", "Enter a GitHub repo (owner/repo or full URL).")
+            return
+
+        plugins_dir_str = self.plugins_dir_edit.text().strip()
+        if not plugins_dir_str:
+            QMessageBox.warning(
+                self, "Install Plugin",
+                "Set a Plugins Directory first — the plugin will be extracted there."
+            )
+            return
+
+        from pathlib import Path
+        plugins_dir = Path(plugins_dir_str)
+
+        # Normalise input to owner/repo
+        repo_input = repo_input.rstrip('/')
+        if repo_input.startswith('https://github.com/'):
+            repo_slug = repo_input[len('https://github.com/'):]
+        elif repo_input.startswith('github.com/'):
+            repo_slug = repo_input[len('github.com/'):]
+        else:
+            repo_slug = repo_input
+
+        # Strip any trailing path segments beyond owner/repo
+        parts = repo_slug.split('/')
+        if len(parts) < 2:
+            QMessageBox.warning(self, "Install Plugin", f"Could not parse repo from: {repo_input}")
+            return
+        owner, repo = parts[0], parts[1]
+
+        # Try main then master branch
+        installed = False
+        last_error = None
+        for branch in ('main', 'master'):
+            zip_url = f"https://github.com/{owner}/{repo}/archive/refs/heads/{branch}.zip"
+            try:
+                with urllib.request.urlopen(zip_url, timeout=30) as resp:
+                    zip_data = resp.read()
+
+                with zipfile.ZipFile(io.BytesIO(zip_data)) as zf:
+                    # The ZIP contains a top-level folder like repo-main/
+                    top_dirs = {n.split('/')[0] for n in zf.namelist() if '/' in n}
+                    if len(top_dirs) != 1:
+                        QMessageBox.warning(
+                            self, "Install Plugin",
+                            "Unexpected ZIP structure — could not determine module root."
+                        )
+                        return
+                    zip_root = top_dirs.pop()
+
+                    # Extract to a temp dir, then move the contents into plugins_dir
+                    with tempfile.TemporaryDirectory() as tmp:
+                        zf.extractall(tmp)
+                        src_root = Path(tmp) / zip_root
+
+                        # If the extracted folder itself contains module.py it IS the module;
+                        # otherwise look one level deeper for a folder with module.py.
+                        if (src_root / 'module.py').exists():
+                            dest = plugins_dir / repo
+                            if dest.exists():
+                                shutil.rmtree(dest)
+                            shutil.copytree(src_root, dest)
+                            module_name = repo
+                        else:
+                            candidates = [
+                                d for d in src_root.iterdir()
+                                if d.is_dir() and (d / 'module.py').exists()
+                            ]
+                            if not candidates:
+                                QMessageBox.warning(
+                                    self, "Install Plugin",
+                                    f"No module.py found in {owner}/{repo}. "
+                                    "Ensure the repo contains a JobDocs plugin module."
+                                )
+                                return
+                            module_folder = candidates[0]
+                            dest = plugins_dir / module_folder.name
+                            if dest.exists():
+                                shutil.rmtree(dest)
+                            shutil.copytree(module_folder, dest)
+                            module_name = module_folder.name
+
+                plugins_dir.mkdir(parents=True, exist_ok=True)
+                QMessageBox.information(
+                    self, "Plugin Installed",
+                    f"Plugin '{module_name}' installed to:\n{dest}\n\nRestart JobDocs to load it."
+                )
+                self.github_repo_edit.clear()
+                installed = True
+                break
+
+            except urllib.error.HTTPError as e:
+                last_error = str(e)
+                continue
+            except Exception as e:
+                QMessageBox.critical(self, "Install Plugin", f"Download failed:\n{e}")
+                return
+
+        if not installed:
+            QMessageBox.critical(
+                self, "Install Plugin",
+                f"Could not download {owner}/{repo} (tried main and master branches).\n{last_error}"
+            )
+
     def browse_dir(self, line_edit: QLineEdit):
         dir_path = QFileDialog.getExistingDirectory(self, "Select Directory")
         if dir_path:
@@ -331,5 +473,8 @@ class SettingsDialog(QDialog):
 
         # Save remote server path
         self.settings['remote_server_path'] = self.remote_server_edit.text().strip()
+
+        # Save plugins directory
+        self.settings['plugins_dir'] = self.plugins_dir_edit.text().strip()
 
         self.accept()

--- a/core/settings_dialog.py
+++ b/core/settings_dialog.py
@@ -121,12 +121,13 @@ class SettingsDialog(QDialog):
     """Settings dialog"""
 
     def __init__(self, settings: Dict[str, Any], parent=None, available_modules: List[tuple] = None,
-                 save_callback=None):
+                 save_callback=None, plugins_dir: Path = None):
         super().__init__(parent)
         self.settings = settings.copy()
         self.available_modules = available_modules or []  # List of (module_name, display_name) tuples
         self.module_checkboxes = {}  # Store module checkboxes
         self._save_callback = save_callback  # Called to persist settings to disk mid-dialog
+        self._plugins_dir = plugins_dir
         self.setWindowTitle("Settings")
         self.setMinimumWidth(600)
         self.setup_ui()
@@ -186,31 +187,24 @@ class SettingsDialog(QDialog):
 
         scroll_layout.addWidget(itar_group)
 
-        # Plugins directory group
-        plugins_group = QGroupBox("Plugins Directory (optional)")
+        # Plugins group
+        plugins_group = QGroupBox("Plugins")
         plugins_layout = QGridLayout(plugins_group)
 
-        plugins_layout.addWidget(QLabel("Plugins Directory:"), 0, 0)
-        self.plugins_dir_edit = QLineEdit(self.settings.get('plugins_dir', ''))
-        self.plugins_dir_edit.setPlaceholderText("Folder containing external plugin modules")
-        plugins_layout.addWidget(self.plugins_dir_edit, 0, 1)
-        plugins_btn = QPushButton("Browse...")
-        plugins_btn.clicked.connect(lambda: self.browse_dir(self.plugins_dir_edit))
-        plugins_layout.addWidget(plugins_btn, 0, 2)
-
-        plugins_info = QLabel("Drop a plugin module folder here to load it at startup (requires restart)")
-        plugins_info.setWordWrap(True)
-        plugins_info.setStyleSheet("color: gray; font-size: 9pt;")
-        plugins_layout.addWidget(plugins_info, 1, 0, 1, 3)
+        plugins_dir_label = QLabel(str(self._plugins_dir) if self._plugins_dir else "(not configured)")
+        plugins_dir_label.setStyleSheet("color: gray; font-size: 9pt;")
+        plugins_dir_label.setWordWrap(True)
+        plugins_layout.addWidget(QLabel("Plugins folder:"), 0, 0)
+        plugins_layout.addWidget(plugins_dir_label, 0, 1, 1, 2)
 
         # GitHub install row
-        plugins_layout.addWidget(QLabel("Install from GitHub:"), 2, 0)
+        plugins_layout.addWidget(QLabel("Install from GitHub:"), 1, 0)
         self.github_repo_edit = QLineEdit()
         self.github_repo_edit.setPlaceholderText("owner/repo  or  https://github.com/owner/repo")
-        plugins_layout.addWidget(self.github_repo_edit, 2, 1)
+        plugins_layout.addWidget(self.github_repo_edit, 1, 1)
         self.github_install_btn = QPushButton("Install")
         self.github_install_btn.clicked.connect(self._install_github_plugin)
-        plugins_layout.addWidget(self.github_install_btn, 2, 2)
+        plugins_layout.addWidget(self.github_install_btn, 1, 2)
 
         scroll_layout.addWidget(plugins_group)
 
@@ -422,18 +416,9 @@ class SettingsDialog(QDialog):
             QMessageBox.warning(self, "Install Plugin", "Enter a GitHub repo (owner/repo or full URL).")
             return
 
-        plugins_dir_str = self.plugins_dir_edit.text().strip()
-        if not plugins_dir_str:
-            QMessageBox.warning(
-                self, "Install Plugin",
-                "Set a Plugins Directory first — the plugin will be extracted there."
-            )
+        if not self._plugins_dir:
+            QMessageBox.warning(self, "Install Plugin", "Plugins directory is not configured.")
             return
-
-        # Persist immediately so the value survives if the dialog is closed without Save.
-        self.settings['plugins_dir'] = plugins_dir_str
-        if self._save_callback:
-            self._save_callback({'plugins_dir': plugins_dir_str})
 
         # Normalise input to owner/repo
         repo_input = repo_input.rstrip('/')
@@ -451,7 +436,7 @@ class SettingsDialog(QDialog):
         owner, repo = parts[0], parts[1]
 
         self.github_install_btn.setEnabled(False)
-        worker = _PluginInstallWorker(owner, repo, Path(plugins_dir_str))
+        worker = _PluginInstallWorker(owner, repo, self._plugins_dir)
         worker.success.connect(lambda name, dest: self._on_plugin_install_success(name, dest, worker))
         worker.error.connect(lambda msg: self._on_plugin_install_error(msg, worker))
         self._install_worker = worker  # prevent GC while running
@@ -515,8 +500,5 @@ class SettingsDialog(QDialog):
 
         # Save remote server path
         self.settings['remote_server_path'] = self.remote_server_edit.text().strip()
-
-        # Save plugins directory
-        self.settings['plugins_dir'] = self.plugins_dir_edit.text().strip()
 
         self.accept()

--- a/main.py
+++ b/main.py
@@ -50,7 +50,6 @@ class JobDocsMainWindow(QMainWindow):
         'report_template_path': '',  # Path to Excel template for Report Fixer
         'suppress_bp_link_notification': False,  # Suppress "linked to blueprints" confirmation dialog
         'skip_image_attachments': True,
-        'plugins_dir': '',  # Local folder containing external plugin modules
     }
 
     def __init__(self):
@@ -232,12 +231,16 @@ class JobDocsMainWindow(QMainWindow):
 
     # ==================== Module Loading ====================
 
+    def _get_plugins_dir(self) -> Path:
+        """Return the fixed plugins directory alongside the executable (or repo root in dev)."""
+        if getattr(sys, 'frozen', False):
+            return Path(sys.executable).parent / 'plugins'
+        return Path(__file__).parent / 'plugins'
+
     def load_modules(self):
         """Load all modules using the module loader"""
         modules_dir = Path(__file__).parent / 'modules'
-        plugins_dir_str = self.settings.get('plugins_dir', '')
-        plugins_dir = Path(plugins_dir_str) if plugins_dir_str else None
-        loader = ModuleLoader(modules_dir, plugins_dir=plugins_dir)
+        loader = ModuleLoader(modules_dir, plugins_dir=self._get_plugins_dir())
 
         try:
             # Load modules with experimental flag and disabled modules list
@@ -323,9 +326,7 @@ class JobDocsMainWindow(QMainWindow):
 
         # Discover all available modules for the settings dialog
         modules_dir = Path(__file__).parent / 'modules'
-        plugins_dir_str = self.settings.get('plugins_dir', '')
-        plugins_dir = Path(plugins_dir_str) if plugins_dir_str else None
-        loader = ModuleLoader(modules_dir, plugins_dir=plugins_dir)
+        loader = ModuleLoader(modules_dir, plugins_dir=self._get_plugins_dir())
         available_module_names = loader.discover_modules()
 
         # Create list of (module_name, display_name) tuples
@@ -342,7 +343,8 @@ class JobDocsMainWindow(QMainWindow):
                 available_modules.append((module_name, module_name))
 
         dialog = SettingsDialog(self.settings, self, available_modules,
-                               save_callback=self._partial_save_settings)
+                               save_callback=self._partial_save_settings,
+                               plugins_dir=self._get_plugins_dir())
         if dialog.exec() == QDialog.DialogCode.Accepted:
             self.settings = dialog.settings
 

--- a/main.py
+++ b/main.py
@@ -49,7 +49,8 @@ class JobDocsMainWindow(QMainWindow):
         'remote_server_path': '',  # Network path or URL for remote settings sync
         'report_template_path': '',  # Path to Excel template for Report Fixer
         'suppress_bp_link_notification': False,  # Suppress "linked to blueprints" confirmation dialog
-        'skip_image_attachments': True
+        'skip_image_attachments': True,
+        'plugins_dir': '',  # Local folder containing external plugin modules
     }
 
     def __init__(self):
@@ -229,7 +230,9 @@ class JobDocsMainWindow(QMainWindow):
     def load_modules(self):
         """Load all modules using the module loader"""
         modules_dir = Path(__file__).parent / 'modules'
-        loader = ModuleLoader(modules_dir)
+        plugins_dir_str = self.settings.get('plugins_dir', '')
+        plugins_dir = Path(plugins_dir_str) if plugins_dir_str else None
+        loader = ModuleLoader(modules_dir, plugins_dir=plugins_dir)
 
         try:
             # Load modules with experimental flag and disabled modules list
@@ -315,7 +318,9 @@ class JobDocsMainWindow(QMainWindow):
 
         # Discover all available modules for the settings dialog
         modules_dir = Path(__file__).parent / 'modules'
-        loader = ModuleLoader(modules_dir)
+        plugins_dir_str = self.settings.get('plugins_dir', '')
+        plugins_dir = Path(plugins_dir_str) if plugins_dir_str else None
+        loader = ModuleLoader(modules_dir, plugins_dir=plugins_dir)
         available_module_names = loader.discover_modules()
 
         # Create list of (module_name, display_name) tuples

--- a/main.py
+++ b/main.py
@@ -159,6 +159,11 @@ class JobDocsMainWindow(QMainWindow):
 
         return self.DEFAULT_SETTINGS.copy()
 
+    def _partial_save_settings(self, partial: Dict[str, Any]):
+        """Merge partial settings dict and persist to disk (used by mid-dialog callbacks)."""
+        self.settings.update(partial)
+        self.save_settings()
+
     def save_settings(self):
         """Save settings to file and sync to remote server if configured"""
         try:
@@ -336,7 +341,8 @@ class JobDocsMainWindow(QMainWindow):
                 # If we can't load it, just use the module name
                 available_modules.append((module_name, module_name))
 
-        dialog = SettingsDialog(self.settings, self, available_modules)
+        dialog = SettingsDialog(self.settings, self, available_modules,
+                               save_callback=self._partial_save_settings)
         if dialog.exec() == QDialog.DialogCode.Accepted:
             self.settings = dialog.settings
 


### PR DESCRIPTION
## Summary
- **Plugins Directory setting** — users browse to a local folder; any subfolder containing `module.py` is loaded as a plugin at startup (works in both dev mode and the frozen `.exe`)
- **Install from GitHub** — enter `owner/repo` or a full GitHub URL in Settings → Plugins Directory → Install from GitHub; the app downloads the ZIP, finds the module folder, and extracts it into the plugins directory
- **External plugins bypass the experimental gate** — placing a plugin in the plugins dir is an explicit opt-in, so `experimental_features` isn't required

## How it works
- `ModuleLoader` now accepts a `plugins_dir` param
- In frozen mode: scans `plugins_dir` on disk alongside the hardcoded built-in module list; plugins are loaded via `importlib.util.spec_from_file_location` (no need to bundle them into the exe)
- In dev mode: same filesystem scan, scanned alongside `modules/`
- GitHub install uses `urllib` (stdlib) — downloads `main`/`master` ZIP, finds the first subfolder with `module.py`, extracts to plugins dir

## Test plan
- [ ] Set a plugins dir, drop a module folder in, restart — confirm tab appears
- [ ] Install a plugin via the GitHub field, confirm it lands in plugins dir and loads on restart
- [ ] Confirm built-in modules still load normally with no plugins dir set
- [ ] Confirm frozen exe loads plugins from plugins dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure and use a local plugins directory so external plugins can be discovered and loaded.
  * Install plugins from GitHub via the Settings dialog with input validation and clear success/error feedback; the dialog shows the configured plugins path.
  * Settings now support immediate in-dialog persistence of changes.

* **Chores**
  * Installer now creates and preserves a persistent plugins folder during uninstall.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->