### PR TITLE
fix: bundle pandas/openpyxl for plugins and restore plugin installer

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,8 +7,8 @@ You are a senior software developer. These rules override your default behavior.
 Before taking any action on this project — including edits, commits, or file creation:
 
 1. Read `.claude/CLAUDE.md` and `.claude/S&P.md`.
-2. Run `gh pr list` — if a PR exists for the current branch, run `gh pr view <number> --comments` and read all CodeRabbit comments before proceeding.
-3. Do not make any edits until outstanding CR findings are addressed or acknowledged.
+2. Run `gh pr list` — if a PR exists for the current branch, run `gh pr view <number> --comments` and read **all comments** (CodeRabbit and human) before proceeding.
+3. Do not make any edits until all outstanding findings and review comments are addressed or acknowledged.
 
 No exceptions.
 
@@ -89,17 +89,17 @@ git push origin v1.2.3
 
 **SignPath:** Apply at https://signpath.io/product/open-source. Once approved, uncomment the signing step in `build-release.yml` and add `SIGNPATH_API_TOKEN` and `SIGNPATH_ORG_ID` to GitHub Actions secrets.
 
-## Rule 5: CodeRabbit Pull Request Reviews
+## Rule 5: Pull Request Reviews
 
 When a pull request is open or being prepared:
 
 - Always open PRs via `gh pr create` — never merge directly to `master` without a PR.
-- After CodeRabbit submits its review, read the review comments before making any further changes.
-- For each CodeRabbit finding:
+- After any review is submitted (CodeRabbit **or human**), read all comments before making any further changes.
+- For each finding, regardless of source:
   1. If it matches an existing `.claude/S&P.md` entry — fix it immediately and reference the S&P entry in the commit message.
   2. If it is a new pattern — fix it, then append it to `.claude/S&P.md` in the standard format before committing.
-- Do not dismiss or ignore CodeRabbit nitpicks — log them to `.claude/S&P.md` even if not immediately actionable.
-- Only merge a PR after all blocking CodeRabbit comments are resolved.
+- Do not dismiss or ignore nitpicks — log them to `.claude/S&P.md` even if not immediately actionable.
+- Only merge a PR after all blocking comments are resolved.
 
 ### S&P.md Entry Format
 

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -3863,3 +3863,105 @@ Reviewing files that changed from the base of the PR and between c1067e4bd0a622c
 </details>
 
 <!-- This is an auto-generated comment by CodeRabbit for review status -->
+
+---
+
+## 2026-04-14 — `PR #18: fix: bundle pandas/openpyxl for plugins and restore plugin installer` — review run 1
+
+**Actionable comments posted: 4**
+
+<details>
+<summary>🤖 Prompt for all review comments with AI agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+Inline comments:
+In `@main.py`:
+- Around line 50-51: The code currently assumes branches ('main','master') in
+the for loop that constructs zip_url, which will fail for repos with other
+default branches; change the logic to first query the repo metadata from
+GitHub's API (GET https://api.github.com/repos/{owner}/{repo}) and read the
+default_branch field, then build zip_url using that default_branch value; if the
+API call is rate-limited or fails, fall back to prompting the user for a branch
+name (or only then try the ('main','master') fallback). Update the code paths
+that construct zip_url (the loop using zip_url and any related download
+functions) to use the resolved branch variable instead of the hard-coded tuple.
+- Around line 72-85: The code currently picks the first directory with module.py
+(candidates list -> module_folder) which is ambiguous; change the logic to fail
+fast unless there is exactly one candidate: after building candidates (variable
+candidates), if len(candidates) == 0 emit the existing error, if len(candidates)
+> 1 emit an error listing the ambiguous candidate names (or count) and return,
+otherwise proceed setting module_folder = candidates[0] and computing dest,
+module_name, src as before; update any tests or messages to mention ambiguous
+plugin roots so callers know to disambiguate.
+- Around line 87-98: The current sequence removes the existing plugin (dest)
+before committing the new copy, risking data loss if tmp_dest.rename(dest)
+fails; change to a safe swap: after creating tmp_dest (tmp_dest =
+dest.with_name(dest.name + '.tmp')), do not delete dest—first move/rename the
+current dest to a backup (e.g., backup_dest = dest.with_name(dest.name +
+'.backup')) ensuring any preexisting backup is removed, then rename tmp_dest to
+dest, and only after successful rename remove the backup; on any exception,
+attempt to restore from backup (rename backup_dest back to dest) and clean up
+tmp_dest and backup_dest with ignore_errors=True. Ensure all operations
+reference tmp_dest, dest, src and handle exceptions to avoid leaving the system
+without a working plugin.
+- Around line 44-48: The plugins_dir.mkdir call in run executes before the
+worker's try block so a PermissionError will terminate the thread without
+invoking the worker's error handling; wrap the directory creation in the same
+error-handling as the worker (or add a local try/except around
+plugins_dir.mkdir) and on failure call the worker's error-emission path (e.g.,
+call self.error or the same error handler used inside run) passing the caught
+exception, then abort/return to avoid continuing; locate symbols run,
+self._plugins_dir, plugins_dir.mkdir and the worker's existing try/except to
+integrate the mkdir into that error flow.
+```
+
+</details>
+
+<details>
+<summary>🪄 Autofix (Beta)</summary>
+
+Fix all unresolved CodeRabbit comments on this PR:
+
+- [ ] <!-- {"checkboxId": "4b0d0e0a-96d7-4f10-b296-3a18ea78f0b9"} --> Push a commit to this branch (recommended)
+- [ ] <!-- {"checkboxId": "ff5b1114-7d8c-49e6-8ac1-43f82af23a33"} --> Create a new PR with the fixes
+
+</details>
+
+---
+
+<details>
+<summary>ℹ️ Review info</summary>
+
+<details>
+<summary>⚙️ Run configuration</summary>
+
+**Configuration used**: Path: .coderabbit.yaml
+
+**Review profile**: CHILL
+
+**Plan**: Pro
+
+**Run ID**: `5485000d-3ec1-4426-9e5b-fcd82626e30e`
+
+</details>
+
+<details>
+<summary>📥 Commits</summary>
+
+Reviewing files that changed from the base of the PR and between ce304ec214964c6ba34efc2c08887f2aa3ca26eb and 4ff59fb26bb2512772bd11b08022001244156741.
+
+</details>
+
+<details>
+<summary>📒 Files selected for processing (2)</summary>
+
+* `build_scripts/JobDocs.spec`
+* `main.py`
+
+</details>
+
+</details>
+
+<!-- This is an auto-generated comment by CodeRabbit for review status -->

--- a/build_scripts/JobDocs.spec
+++ b/build_scripts/JobDocs.spec
@@ -157,12 +157,14 @@ hiddenimports = [
 
 # Third-party packages required by plugins (e.g. jobdocs-report-fixer uses pandas + openpyxl).
 #
-# Architectural note: ideally plugin dependencies would be self-contained within each plugin
-# (e.g. a deps/ subfolder added to sys.path by the plugin loader). However, PyInstaller
-# performs static analysis at build time and cannot discover imports made by plugins that
-# are loaded dynamically at runtime — there is no pip inside the bundled exe to install
-# anything after the fact. Until a per-plugin deps/ system is implemented, shared plugin
-# dependencies must be declared here so PyInstaller includes them in the bundle.
+# Architectural note: because this is a onedir build, pure-Python plugin dependencies
+# could in principle live in a plugin's own deps/ subfolder (added to sys.path by the
+# plugin loader before exec_module). However, pandas contains compiled .pyd extensions
+# that must exactly match the Python version bundled by PyInstaller — they cannot be
+# shipped portably alongside a plugin. pandas must therefore be declared here so
+# PyInstaller includes the correct pre-compiled binaries in the bundle.
+# openpyxl is included here for the same reason as pandas (consistency and to avoid
+# a split deps model until a proper per-plugin deps/ system is implemented).
 hiddenimports += collect_submodules('pandas')
 hiddenimports += collect_submodules('openpyxl')
 datas += collect_data_files('pandas')

--- a/build_scripts/JobDocs.spec
+++ b/build_scripts/JobDocs.spec
@@ -156,7 +156,13 @@ hiddenimports = [
 ]
 
 # Third-party packages required by plugins (e.g. jobdocs-report-fixer uses pandas + openpyxl).
-# collect_submodules is needed because PyInstaller cannot trace dynamic imports inside plugins.
+#
+# Architectural note: ideally plugin dependencies would be self-contained within each plugin
+# (e.g. a deps/ subfolder added to sys.path by the plugin loader). However, PyInstaller
+# performs static analysis at build time and cannot discover imports made by plugins that
+# are loaded dynamically at runtime — there is no pip inside the bundled exe to install
+# anything after the fact. Until a per-plugin deps/ system is implemented, shared plugin
+# dependencies must be declared here so PyInstaller includes them in the bundle.
 hiddenimports += collect_submodules('pandas')
 hiddenimports += collect_submodules('openpyxl')
 datas += collect_data_files('pandas')

--- a/build_scripts/JobDocs.spec
+++ b/build_scripts/JobDocs.spec
@@ -153,10 +153,13 @@ hiddenimports = [
 
     # stdlib modules used by dynamically-loaded plugins (not reachable via static analysis)
     'difflib',
-
-    # NOTE: modules.reporting, pandas, openpyxl are PSM-only (Rule 3).
-    # Include them only in a PSM-specific build spec, not here.
 ]
+
+# Third-party packages required by plugins (e.g. jobdocs-report-fixer uses pandas + openpyxl).
+# collect_submodules is needed because PyInstaller cannot trace dynamic imports inside plugins.
+hiddenimports += collect_submodules('pandas')
+hiddenimports += collect_submodules('openpyxl')
+datas += collect_data_files('pandas')
 
 # Find main.py
 main_py = spec_root / 'main.py'

--- a/main.py
+++ b/main.py
@@ -5,21 +5,111 @@ JobDocs - Modular Blueprint and Job Management System
 Main application entry point using the modular plugin architecture.
 """
 
+import io
+import shutil
 import sys
 import json
+import tempfile
+import urllib.error
+import urllib.request
+import zipfile
 from pathlib import Path
 from datetime import datetime
 from typing import Dict, Any, List
-from PyQt6.QtWidgets import (
-    QApplication, QMainWindow, QTabWidget, QMessageBox, QDialog
-)
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import Qt, QThread, pyqtSignal
 from PyQt6.QtGui import QIcon
+from PyQt6.QtWidgets import (
+    QApplication, QMainWindow, QTabWidget, QMessageBox, QDialog,
+    QInputDialog, QLineEdit
+)
 
 from core.module_loader import ModuleLoader
 from core.app_context import AppContext
 from shared.utils import get_config_dir, get_os_text
 from shared.remote_sync import RemoteSyncManager
+
+
+class _PluginInstallWorker(QThread):
+    """Background worker that downloads and extracts a GitHub plugin."""
+
+    success = pyqtSignal(str, str)  # module_name, dest_path
+    error = pyqtSignal(str)
+
+    def __init__(self, owner: str, repo: str, plugins_dir: Path):
+        super().__init__()
+        self._owner = owner
+        self._repo = repo
+        self._plugins_dir = plugins_dir
+
+    def run(self):
+        owner, repo = self._owner, self._repo
+        plugins_dir = self._plugins_dir
+        plugins_dir.mkdir(parents=True, exist_ok=True)
+
+        last_error = None
+        for branch in ('main', 'master'):
+            zip_url = f"https://github.com/{owner}/{repo}/archive/refs/heads/{branch}.zip"
+            try:
+                with urllib.request.urlopen(zip_url, timeout=30) as resp:
+                    zip_data = resp.read()
+
+                with zipfile.ZipFile(io.BytesIO(zip_data)) as zf:
+                    top_dirs = {n.split('/')[0] for n in zf.namelist() if '/' in n}
+                    if len(top_dirs) != 1:
+                        self.error.emit("Unexpected ZIP structure — could not determine module root.")
+                        return
+                    zip_root = top_dirs.pop()
+
+                    with tempfile.TemporaryDirectory() as tmp:
+                        zf.extractall(tmp)
+                        src_root = Path(tmp) / zip_root
+
+                        if (src_root / 'module.py').exists():
+                            dest = plugins_dir / repo
+                            module_name = repo
+                            src = src_root
+                        else:
+                            candidates = [
+                                d for d in src_root.iterdir()
+                                if d.is_dir() and (d / 'module.py').exists()
+                            ]
+                            if not candidates:
+                                self.error.emit(
+                                    f"No module.py found in {owner}/{repo}. "
+                                    "Ensure the repo contains a JobDocs plugin module."
+                                )
+                                return
+                            module_folder = candidates[0]
+                            dest = plugins_dir / module_folder.name
+                            module_name = module_folder.name
+                            src = module_folder
+
+                        tmp_dest = dest.with_name(dest.name + '.tmp')
+                        try:
+                            if tmp_dest.exists():
+                                shutil.rmtree(tmp_dest)
+                            shutil.copytree(src, tmp_dest)
+                            if dest.exists():
+                                shutil.rmtree(dest)
+                            tmp_dest.rename(dest)
+                        except Exception:
+                            if tmp_dest.exists():
+                                shutil.rmtree(tmp_dest, ignore_errors=True)
+                            raise
+
+                self.success.emit(module_name, str(dest))
+                return
+
+            except urllib.error.HTTPError as e:
+                last_error = str(e)
+                continue
+            except Exception as e:
+                self.error.emit(f"Download failed:\n{e}")
+                return
+
+        self.error.emit(
+            f"Could not download {owner}/{repo} (tried main and master branches).\n{last_error}"
+        )
 
 
 class JobDocsMainWindow(QMainWindow):
@@ -297,6 +387,9 @@ class JobDocsMainWindow(QMainWindow):
         settings_action = file_menu.addAction("&Settings")  # pyright: ignore[reportOptionalMemberAccess]
         settings_action.triggered.connect(self.open_settings)  # pyright: ignore[reportOptionalMemberAccess]
 
+        install_plugin_action = file_menu.addAction("&Install Plugin...")  # pyright: ignore[reportOptionalMemberAccess]
+        install_plugin_action.triggered.connect(self.install_plugin)  # pyright: ignore[reportOptionalMemberAccess]
+
         file_menu.addSeparator()  # pyright: ignore[reportOptionalMemberAccess]
 
         exit_action = file_menu.addAction("E&xit")  # pyright: ignore[reportOptionalMemberAccess]
@@ -356,6 +449,49 @@ class JobDocsMainWindow(QMainWindow):
             from shared.widgets import DropZone
             DropZone.set_skip_image_attachments(self.settings.get('skip_image_attachments', True))
             QMessageBox.information(self, "Settings", "Settings saved. Please restart for all changes to take effect.")
+
+    def install_plugin(self):
+        """Prompt for a GitHub repo and install it as a plugin."""
+        repo_input, ok = QInputDialog.getText(
+            self, "Install Plugin",
+            "GitHub repo (owner/repo or https://github.com/owner/repo):",
+            QLineEdit.EchoMode.Normal
+        )
+        if not ok or not repo_input.strip():
+            return
+
+        repo_input = repo_input.strip().rstrip('/')
+        if repo_input.startswith('https://github.com/'):
+            repo_slug = repo_input[len('https://github.com/'):]
+        elif repo_input.startswith('github.com/'):
+            repo_slug = repo_input[len('github.com/'):]
+        else:
+            repo_slug = repo_input
+
+        parts = repo_slug.split('/')
+        if len(parts) < 2:
+            QMessageBox.warning(self, "Install Plugin", f"Could not parse repo from: {repo_input}")
+            return
+
+        owner, repo = parts[0], parts[1]
+        plugins_dir = self._get_plugins_dir()
+
+        worker = _PluginInstallWorker(owner, repo, plugins_dir)
+        worker.success.connect(lambda name, dest: self._on_plugin_install_success(name, dest, worker))
+        worker.error.connect(lambda msg: self._on_plugin_install_error(msg, worker))
+        self._install_worker = worker  # prevent GC while running
+        worker.start()
+
+    def _on_plugin_install_success(self, module_name: str, dest: str, worker: _PluginInstallWorker):
+        QMessageBox.information(
+            self, "Plugin Installed",
+            f"Plugin '{module_name}' installed to:\n{dest}\n\nRestart JobDocs to load it."
+        )
+        worker.deleteLater()
+
+    def _on_plugin_install_error(self, message: str, worker: _PluginInstallWorker):
+        QMessageBox.critical(self, "Install Plugin", message)
+        worker.deleteLater()
 
     def show_getting_started(self):
         """Show getting started guide"""

--- a/main.py
+++ b/main.py
@@ -44,10 +44,27 @@ class _PluginInstallWorker(QThread):
     def run(self):
         owner, repo = self._owner, self._repo
         plugins_dir = self._plugins_dir
-        plugins_dir.mkdir(parents=True, exist_ok=True)
+
+        # Fix CR: wrap mkdir so PermissionError is surfaced via error signal
+        try:
+            plugins_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            self.error.emit(f"Could not create plugins directory:\n{plugins_dir}\n\n{e}")
+            return
+
+        # Fix CR: resolve default branch from GitHub API; fall back to main/master
+        branches_to_try: list = []
+        try:
+            api_url = f"https://api.github.com/repos/{owner}/{repo}"
+            req = urllib.request.Request(api_url, headers={"Accept": "application/vnd.github+json"})
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                meta = json.loads(resp.read())
+            branches_to_try = [meta.get("default_branch", "main")]
+        except Exception:
+            branches_to_try = ["main", "master"]
 
         last_error = None
-        for branch in ('main', 'master'):
+        for branch in branches_to_try:
             zip_url = f"https://github.com/{owner}/{repo}/archive/refs/heads/{branch}.zip"
             try:
                 with urllib.request.urlopen(zip_url, timeout=30) as resp:
@@ -79,22 +96,37 @@ class _PluginInstallWorker(QThread):
                                     "Ensure the repo contains a JobDocs plugin module."
                                 )
                                 return
+                            # Fix CR: fail fast if multiple plugin roots are found
+                            if len(candidates) > 1:
+                                self.error.emit(
+                                    f"Found multiple plugin roots in {owner}/{repo}. "
+                                    "Ensure the repo contains exactly one JobDocs plugin module."
+                                )
+                                return
                             module_folder = candidates[0]
                             dest = plugins_dir / module_folder.name
                             module_name = module_folder.name
                             src = module_folder
 
+                        # Fix CR: backup-then-swap so the old plugin survives a failed rename
                         tmp_dest = dest.with_name(dest.name + '.tmp')
+                        backup_dest = dest.with_name(dest.name + '.bak')
                         try:
                             if tmp_dest.exists():
                                 shutil.rmtree(tmp_dest)
+                            if backup_dest.exists():
+                                shutil.rmtree(backup_dest)
                             shutil.copytree(src, tmp_dest)
                             if dest.exists():
-                                shutil.rmtree(dest)
+                                dest.rename(backup_dest)
                             tmp_dest.rename(dest)
+                            if backup_dest.exists():
+                                shutil.rmtree(backup_dest)
                         except Exception:
                             if tmp_dest.exists():
                                 shutil.rmtree(tmp_dest, ignore_errors=True)
+                            if backup_dest.exists() and not dest.exists():
+                                backup_dest.rename(dest)
                             raise
 
                 self.success.emit(module_name, str(dest))
@@ -108,7 +140,7 @@ class _PluginInstallWorker(QThread):
                 return
 
         self.error.emit(
-            f"Could not download {owner}/{repo} (tried main and master branches).\n{last_error}"
+            f"Could not download {owner}/{repo} (tried: {', '.join(branches_to_try)}).\n{last_error}"
         )
 
 


### PR DESCRIPTION
## Summary
- `jobdocs-report-fixer` uses `pandas` and `openpyxl` internally (lazy imports). PyInstaller can't trace these through dynamic plugin loading, so they were missing from the bundle — causing the "Missing required packages" error on the Report Fixer tab
- Added `collect_submodules('pandas')`, `collect_submodules('openpyxl')`, and `collect_data_files('pandas')` to `build_scripts/JobDocs.spec`
- Removed the outdated comment that labelled pandas/openpyxl as PSM-only (PSM is deprecated per Rule 3)
- Restored the GitHub plugin installer as **File > Install Plugin...** since it was removed from Settings in #17 but users still need a way to install plugins

## Test plan
- [ ] Rebuild `JobDocs.exe` and install `jobdocs-report-fixer` plugin
- [ ] Open Report Fixer tab — confirm no "Missing required packages" error
- [ ] File > Install Plugin... — confirm dialog appears and installs a plugin to the plugins folder
- [ ] Verify no regression on other tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Install Plugin..." option in File menu to install plugins directly from GitHub repositories. Users can quickly add plugins by providing a repository path.

* **Improvements**
  * Enhanced plugin bundling to properly include pandas and openpyxl dependencies for improved plugin support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->