### PR TITLE
fix: isolate plugin deps into plugin-local deps/ directory

### DIFF
--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -3965,3 +3965,93 @@ Reviewing files that changed from the base of the PR and between ce304ec214964c6
 </details>
 
 <!-- This is an auto-generated comment by CodeRabbit for review status -->
+
+---
+
+## 2026-04-14 — `PR #19: fix: isolate plugin deps into plugin-local deps/ directory` — review run 1
+
+**Actionable comments posted: 4**
+
+<details>
+<summary>🤖 Prompt for all review comments with AI agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+Inline comments:
+In `@main.py`:
+- Around line 55-57: The current creation of deps_dir and subsequent pip install
+into that path (variable deps_dir) can leave stale/partial packages; change the
+flow to create a fresh temporary directory (e.g., temp_deps_dir), run pip
+install --target into that temp directory, verify success, then atomically
+replace/move temp_deps_dir to deps_dir (remove or backup existing deps_dir only
+after successful install) to avoid overlaying and leftover files—apply the same
+pattern for the other install sites referenced around the blocks using deps_dir
+(lines noted 72-77 and 91-92) so installs are always performed into a clean temp
+folder and swapped into place on success.
+- Around line 103-106: The returned error message omits the --target flag so
+users run pip globally; update the string construction that returns the manual
+recovery command to include the plugin-local target by adding --target
+"{deps_dir}" (use the existing deps_dir variable alongside req_file and
+last_err) so the suggested command is pip install --target "{deps_dir}" -r
+"{req_file}" and preserve the existing error text fallback (last_err or 'no
+usable Python found on PATH').
+- Around line 61-67: When sys.frozen is true the code currently appends system
+Python names into candidates before ever trying the embedded pip, causing wheels
+to be chosen for the system ABI; change the candidates construction so that when
+getattr(sys, 'frozen', False) is True you try the bundled pip API
+(pip._internal) first and only then extend with ['python','python3','py'] as a
+last resort—i.e., ensure the candidates list contains a pip._internal attempt
+first in frozen mode and falls back to the system Python names otherwise.
+```
+
+</details>
+
+<details>
+<summary>🪄 Autofix (Beta)</summary>
+
+Fix all unresolved CodeRabbit comments on this PR:
+
+- [ ] <!-- {"checkboxId": "4b0d0e0a-96d7-4f10-b296-3a18ea78f0b9"} --> Push a commit to this branch (recommended)
+- [ ] <!-- {"checkboxId": "ff5b1114-7d8c-49e6-8ac1-43f82af23a33"} --> Create a new PR with the fixes
+
+</details>
+
+---
+
+<details>
+<summary>ℹ️ Review info</summary>
+
+<details>
+<summary>⚙️ Run configuration</summary>
+
+**Configuration used**: Path: .coderabbit.yaml
+
+**Review profile**: CHILL
+
+**Plan**: Pro
+
+**Run ID**: `564b50cc-67cd-49b3-b031-57621bf81fa5`
+
+</details>
+
+<details>
+<summary>📥 Commits</summary>
+
+Reviewing files that changed from the base of the PR and between 09700c52e8b62d3c6ea0ded20e7f767f2741e370 and f00a384bba3632eca3a8fda3be7bb02ee247a6d7.
+
+</details>
+
+<details>
+<summary>📒 Files selected for processing (4)</summary>
+
+* `.gitignore`
+* `build_scripts/JobDocs.spec`
+* `core/module_loader.py`
+* `main.py`
+
+</details>
+
+</details>
+
+<!-- This is an auto-generated comment by CodeRabbit for review status -->

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -4055,3 +4055,25 @@ Reviewing files that changed from the base of the PR and between 09700c52e8b62d3
 </details>
 
 <!-- This is an auto-generated comment by CodeRabbit for review status -->
+
+---
+
+## 2026-04-14 — `main.py` (plugin dep installer — PR #19 findings)
+
+**Review:** CodeRabbit flagged three actionable issues in `_install_deps`.
+**Result:** All three fixed in commit `dad24fb`.
+
+### Findings
+
+1. **Atomic install via temp directory**
+   - Pip into `deps.tmp/` first, then backup-then-swap into `deps/` on success.
+   - Prevents stale/partial packages if install fails mid-way.
+   - Fix applied: backup-then-swap pattern identical to plugin install in `run()`.
+
+2. **Manual recovery command missing `--target`**
+   - Error message said `pip install -r req_file`, which installs globally.
+   - Fix applied: changed to `pip install --target "{deps_dir}" -r "{req_file}"`.
+
+3. **Frozen mode: try bundled pip before system Python**
+   - System Python may have a different ABI than the bundled Python, causing binary wheels to be incompatible.
+   - Fix applied: in frozen mode, attempt `pip._internal.cli.main` first; fall back to `python`/`py` on PATH only after that fails.

--- a/.gitignore
+++ b/.gitignore
@@ -48,8 +48,9 @@ Thumbs.db
 test_output/
 old/
 
-# Plugin-installed dependencies (managed at runtime, not checked in)
-plugins/*/deps/
+# Shared addon packages dir (managed at runtime via pip, not checked in)
+# Lives in %LOCALAPPDATA%\JobDocs\AddonPackages\ — dev symlink if present
+AddonPackages/
 
 # Flatpak — staged binary and icon (copied from build_dist/ by CI, not source files)
 linux/flatpak/JobDocs

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ Thumbs.db
 test_output/
 old/
 
+# Plugin-installed dependencies (managed at runtime, not checked in)
+plugins/*/deps/
+
 # Flatpak — staged binary and icon (copied from build_dist/ by CI, not source files)
 linux/flatpak/JobDocs
 linux/flatpak/icon_256x256.png

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@ itar/
 not itar/
 sample_files/
 test_jobs.csv
-test_dist/
+test_dist*/
+build[0-9]*/
 
 # Claude Code and development notes
 .claude/settings.local.json

--- a/build_scripts/JobDocs.spec
+++ b/build_scripts/JobDocs.spec
@@ -187,6 +187,12 @@ a = Analysis(
         'PIL',
         'IPython',
         'jupyter',
+
+        # PyMuPDF's pymupdf.table optionally imports pandas for table detection;
+        # we only use fitz for page rendering so exclude it to keep plugin deps
+        # out of the main bundle (plugins install their own deps/ at runtime).
+        'pandas',
+        'openpyxl',
     ],
     win_no_prefer_redirects=False,
     win_private_assemblies=False,

--- a/build_scripts/JobDocs.spec
+++ b/build_scripts/JobDocs.spec
@@ -13,7 +13,6 @@ Usage:
 Generated executable will be in the dist/ directory (or custom path if specified).
 """
 
-from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 import os
 from pathlib import Path
 
@@ -155,19 +154,11 @@ hiddenimports = [
     'difflib',
 ]
 
-# Third-party packages required by plugins (e.g. jobdocs-report-fixer uses pandas + openpyxl).
-#
-# Architectural note: because this is a onedir build, pure-Python plugin dependencies
-# could in principle live in a plugin's own deps/ subfolder (added to sys.path by the
-# plugin loader before exec_module). However, pandas contains compiled .pyd extensions
-# that must exactly match the Python version bundled by PyInstaller — they cannot be
-# shipped portably alongside a plugin. pandas must therefore be declared here so
-# PyInstaller includes the correct pre-compiled binaries in the bundle.
-# openpyxl is included here for the same reason as pandas (consistency and to avoid
-# a split deps model until a proper per-plugin deps/ system is implemented).
-hiddenimports += collect_submodules('pandas')
-hiddenimports += collect_submodules('openpyxl')
-datas += collect_data_files('pandas')
+# Plugin dependencies are NOT bundled here.
+# Each plugin manages its own deps in a deps/ subfolder next to its module.py.
+# The module loader prepends that folder to sys.path before exec_module so the
+# plugin can import normally. The plugin installer (main.py) runs pip install
+# --target deps/ from the plugin's requirements.txt at install time.
 
 # Find main.py
 main_py = spec_root / 'main.py'

--- a/build_scripts/JobDocs.spec
+++ b/build_scripts/JobDocs.spec
@@ -152,6 +152,11 @@ hiddenimports = [
 
     # stdlib modules used by dynamically-loaded plugins (not reachable via static analysis)
     'difflib',
+
+    # pip internal API — used by the plugin installer to install plugin deps at
+    # runtime without requiring a separate Python installation on the user's machine.
+    'pip',
+    'pip._internal.cli.main',
 ]
 
 # Plugin dependencies are NOT bundled here.

--- a/core/module_loader.py
+++ b/core/module_loader.py
@@ -150,6 +150,14 @@ class ModuleLoader:
             if not module_path.exists():
                 raise ImportError(f"Plugin module file not found: {module_path}")
 
+            # Prepend the plugin's deps/ directory to sys.path so that packages
+            # installed there (via pip install --target) are importable.
+            deps_dir = module_path.parent / 'deps'
+            if deps_dir.exists():
+                deps_str = str(deps_dir)
+                if deps_str not in sys.path:
+                    sys.path.insert(0, deps_str)
+
             # Register a parent package entry so relative imports (e.g. `from .helpers`)
             # inside the plugin resolve correctly.
             package_name = f"plugins.{module_name}"

--- a/core/module_loader.py
+++ b/core/module_loader.py
@@ -150,14 +150,6 @@ class ModuleLoader:
             if not module_path.exists():
                 raise ImportError(f"Plugin module file not found: {module_path}")
 
-            # Prepend the plugin's deps/ directory to sys.path so that packages
-            # installed there (via pip install --target) are importable.
-            deps_dir = module_path.parent / 'deps'
-            if deps_dir.exists():
-                deps_str = str(deps_dir)
-                if deps_str not in sys.path:
-                    sys.path.insert(0, deps_str)
-
             # Register a parent package entry so relative imports (e.g. `from .helpers`)
             # inside the plugin resolve correctly.
             package_name = f"plugins.{module_name}"

--- a/main.py
+++ b/main.py
@@ -53,58 +53,91 @@ class _PluginInstallWorker(QThread):
             return ''
 
         deps_dir = plugin_dir / 'deps'
+
+        # Install into a temp dir then swap atomically to avoid leaving deps_dir
+        # in a partial state if the install fails mid-way.
+        tmp_deps = deps_dir.with_name('deps.tmp')
         try:
-            deps_dir.mkdir(parents=True, exist_ok=True)
+            if tmp_deps.exists():
+                shutil.rmtree(tmp_deps)
+            tmp_deps.mkdir(parents=True, exist_ok=True)
         except OSError as e:
-            return f"\n\nCould not create deps directory: {e}"
+            return f"\n\nCould not create temp deps directory: {e}"
 
-        # In dev mode sys.executable is Python, so try it first.
-        # In a frozen build it is the exe itself; fall back to system Python,
-        # then to pip's own internal API (bundled with Python/the frozen exe).
-        candidates = []
-        if not getattr(sys, 'frozen', False):
-            candidates.append(sys.executable)
-        candidates.extend(['python', 'python3', 'py'])
-
+        # Fix CR: in frozen mode try the bundled pip API first so wheels are
+        # resolved against the bundled Python ABI, not a system Python that may
+        # differ. Fall back to system Python names only after that attempt fails.
         last_err = ''
-        for python in candidates:
+        installed = False
+
+        if getattr(sys, 'frozen', False):
             try:
-                result = subprocess.run(
-                    [python, '-m', 'pip', 'install',
-                     '--target', str(deps_dir),
-                     '-r', str(req_file)],
-                    capture_output=True, text=True, timeout=120,
-                )
-                if result.returncode == 0:
-                    return ''
-                last_err = (result.stderr or result.stdout).strip()
-            except FileNotFoundError:
-                continue
-            except subprocess.TimeoutExpired:
-                last_err = 'pip install timed out after 120 s'
-                break
+                from pip._internal.cli.main import main as _pip_main  # type: ignore[import]
+                args = ['install', '--target', str(tmp_deps), '-r', str(req_file)]
+                rc = _pip_main(args)
+                installed = (rc == 0)
+                if not installed:
+                    last_err = f'pip internal API exited with code {rc}'
+            except SystemExit as exc:
+                installed = (exc.code or 0) == 0
+                if not installed:
+                    last_err = f'pip internal API exited with code {exc.code}'
+            except Exception as exc:
+                last_err = str(exc)
 
-        # Last resort: call pip's internal API directly (works in frozen builds
-        # where no system Python is on PATH, since pip ships with Python).
+        if not installed:
+            candidates = []
+            if not getattr(sys, 'frozen', False):
+                candidates.append(sys.executable)
+            candidates.extend(['python', 'python3', 'py'])
+
+            for python in candidates:
+                try:
+                    result = subprocess.run(
+                        [python, '-m', 'pip', 'install',
+                         '--target', str(tmp_deps),
+                         '-r', str(req_file)],
+                        capture_output=True, text=True, timeout=120,
+                    )
+                    if result.returncode == 0:
+                        installed = True
+                        break
+                    last_err = (result.stderr or result.stdout).strip()
+                except FileNotFoundError:
+                    continue
+                except subprocess.TimeoutExpired:
+                    last_err = 'pip install timed out after 120 s'
+                    break
+
+        if not installed:
+            shutil.rmtree(tmp_deps, ignore_errors=True)
+            return (
+                f"\n\nPlugin installed, but dependencies could not be installed automatically.\n"
+                f"Run manually: pip install --target \"{deps_dir}\" -r \"{req_file}\"\n\n"
+                f"Error: {last_err or 'no usable Python found on PATH'}"
+            )
+
+        # Atomically swap temp dir into place (backup-then-swap).
+        backup = deps_dir.with_name('deps.bak')
         try:
-            from pip._internal.cli.main import main as _pip_main  # type: ignore[import]
-            args = ['install', '--target', str(deps_dir), '-r', str(req_file)]
-            rc = _pip_main(args)
-            if rc == 0:
-                return ''
-            last_err = f'pip internal API exited with code {rc}'
-        except SystemExit as exc:
-            if (exc.code or 0) == 0:
-                return ''
-            last_err = f'pip internal API exited with code {exc.code}'
-        except Exception as exc:
-            last_err = str(exc)
+            if backup.exists():
+                shutil.rmtree(backup)
+            if deps_dir.exists():
+                deps_dir.rename(backup)
+            tmp_deps.rename(deps_dir)
+            if backup.exists():
+                shutil.rmtree(backup)
+        except Exception:
+            if tmp_deps.exists() and not deps_dir.exists():
+                try:
+                    tmp_deps.rename(deps_dir)
+                except Exception:
+                    pass
+            if backup.exists() and not deps_dir.exists():
+                backup.rename(deps_dir)
+            raise
 
-        return (
-            f"\n\nPlugin installed, but dependencies could not be installed automatically.\n"
-            f"Run manually: pip install -r \"{req_file}\"\n\n"
-            f"Error: {last_err or 'no usable Python found on PATH'}"
-        )
+        return ''
 
     def run(self):
         owner, repo = self._owner, self._repo

--- a/main.py
+++ b/main.py
@@ -52,11 +52,13 @@ class _PluginInstallWorker(QThread):
         if not req_file.exists():
             return ''
 
-        deps_dir = plugin_dir / 'deps'
+        # Shared addon packages dir — all plugins install here so packages
+        # like pandas are not duplicated when multiple plugins need them.
+        deps_dir = get_config_dir() / 'AddonPackages'
 
         # Install into a temp dir then swap atomically to avoid leaving deps_dir
         # in a partial state if the install fails mid-way.
-        tmp_deps = deps_dir.with_name('deps.tmp')
+        tmp_deps = deps_dir.with_name('AddonPackages.tmp')
         try:
             if tmp_deps.exists():
                 shutil.rmtree(tmp_deps)
@@ -836,6 +838,14 @@ Search across all customers and jobs.</p>
 
 def main():
     """Main application entry point"""
+    # Prepend the shared addon packages directory to sys.path so plugin
+    # dependencies installed there are importable before any modules load.
+    addon_packages = get_config_dir() / 'AddonPackages'
+    if addon_packages.exists():
+        addon_str = str(addon_packages)
+        if addon_str not in sys.path:
+            sys.path.insert(0, addon_str)
+
     # Set AppUserModelID so Windows can pin this to the taskbar
     try:
         import ctypes

--- a/main.py
+++ b/main.py
@@ -58,8 +58,9 @@ class _PluginInstallWorker(QThread):
         except OSError as e:
             return f"\n\nCould not create deps directory: {e}"
 
-        # Try to find a usable Python. In dev mode sys.executable is Python.
-        # In a frozen build it is the exe itself, so fall back to system Python.
+        # In dev mode sys.executable is Python, so try it first.
+        # In a frozen build it is the exe itself; fall back to system Python,
+        # then to pip's own internal API (bundled with Python/the frozen exe).
         candidates = []
         if not getattr(sys, 'frozen', False):
             candidates.append(sys.executable)
@@ -82,6 +83,22 @@ class _PluginInstallWorker(QThread):
             except subprocess.TimeoutExpired:
                 last_err = 'pip install timed out after 120 s'
                 break
+
+        # Last resort: call pip's internal API directly (works in frozen builds
+        # where no system Python is on PATH, since pip ships with Python).
+        try:
+            from pip._internal.cli.main import main as _pip_main  # type: ignore[import]
+            args = ['install', '--target', str(deps_dir), '-r', str(req_file)]
+            rc = _pip_main(args)
+            if rc == 0:
+                return ''
+            last_err = f'pip internal API exited with code {rc}'
+        except SystemExit as exc:
+            if (exc.code or 0) == 0:
+                return ''
+            last_err = f'pip internal API exited with code {exc.code}'
+        except Exception as exc:
+            last_err = str(exc)
 
         return (
             f"\n\nPlugin installed, but dependencies could not be installed automatically.\n"

--- a/main.py
+++ b/main.py
@@ -100,6 +100,7 @@ class _PluginInstallWorker(QThread):
                          '--target', str(tmp_deps),
                          '-r', str(req_file)],
                         capture_output=True, text=True, timeout=120,
+                        creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == 'win32' else 0,
                     )
                     if result.returncode == 0:
                         installed = True

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ Main application entry point using the modular plugin architecture.
 
 import io
 import shutil
+import subprocess
 import sys
 import json
 import tempfile
@@ -32,7 +33,7 @@ from shared.remote_sync import RemoteSyncManager
 class _PluginInstallWorker(QThread):
     """Background worker that downloads and extracts a GitHub plugin."""
 
-    success = pyqtSignal(str, str)  # module_name, dest_path
+    success = pyqtSignal(str, str, str)  # module_name, dest_path, dep_warning
     error = pyqtSignal(str)
 
     def __init__(self, owner: str, repo: str, plugins_dir: Path):
@@ -40,6 +41,53 @@ class _PluginInstallWorker(QThread):
         self._owner = owner
         self._repo = repo
         self._plugins_dir = plugins_dir
+
+    def _install_deps(self, plugin_dir: Path) -> str:
+        """Install requirements.txt into plugin_dir/deps/ using pip.
+
+        Returns a non-empty warning string if installation failed or was skipped,
+        or '' on success / no requirements.txt present.
+        """
+        req_file = plugin_dir / 'requirements.txt'
+        if not req_file.exists():
+            return ''
+
+        deps_dir = plugin_dir / 'deps'
+        try:
+            deps_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            return f"\n\nCould not create deps directory: {e}"
+
+        # Try to find a usable Python. In dev mode sys.executable is Python.
+        # In a frozen build it is the exe itself, so fall back to system Python.
+        candidates = []
+        if not getattr(sys, 'frozen', False):
+            candidates.append(sys.executable)
+        candidates.extend(['python', 'python3', 'py'])
+
+        last_err = ''
+        for python in candidates:
+            try:
+                result = subprocess.run(
+                    [python, '-m', 'pip', 'install',
+                     '--target', str(deps_dir),
+                     '-r', str(req_file)],
+                    capture_output=True, text=True, timeout=120,
+                )
+                if result.returncode == 0:
+                    return ''
+                last_err = (result.stderr or result.stdout).strip()
+            except FileNotFoundError:
+                continue
+            except subprocess.TimeoutExpired:
+                last_err = 'pip install timed out after 120 s'
+                break
+
+        return (
+            f"\n\nPlugin installed, but dependencies could not be installed automatically.\n"
+            f"Run manually: pip install -r \"{req_file}\"\n\n"
+            f"Error: {last_err or 'no usable Python found on PATH'}"
+        )
 
     def run(self):
         owner, repo = self._owner, self._repo
@@ -129,7 +177,8 @@ class _PluginInstallWorker(QThread):
                                 backup_dest.rename(dest)
                             raise
 
-                self.success.emit(module_name, str(dest))
+                dep_warning = self._install_deps(dest)
+                self.success.emit(module_name, str(dest), dep_warning)
                 return
 
             except urllib.error.HTTPError as e:
@@ -509,16 +558,17 @@ class JobDocsMainWindow(QMainWindow):
         plugins_dir = self._get_plugins_dir()
 
         worker = _PluginInstallWorker(owner, repo, plugins_dir)
-        worker.success.connect(lambda name, dest: self._on_plugin_install_success(name, dest, worker))
+        worker.success.connect(lambda name, dest, warn: self._on_plugin_install_success(name, dest, warn, worker))
         worker.error.connect(lambda msg: self._on_plugin_install_error(msg, worker))
         self._install_worker = worker  # prevent GC while running
         worker.start()
 
-    def _on_plugin_install_success(self, module_name: str, dest: str, worker: _PluginInstallWorker):
-        QMessageBox.information(
-            self, "Plugin Installed",
-            f"Plugin '{module_name}' installed to:\n{dest}\n\nRestart JobDocs to load it."
-        )
+    def _on_plugin_install_success(self, module_name: str, dest: str, dep_warning: str, worker: _PluginInstallWorker):
+        msg = f"Plugin '{module_name}' installed to:\n{dest}\n\nRestart JobDocs to load it."
+        if dep_warning:
+            QMessageBox.warning(self, "Plugin Installed", msg + dep_warning)
+        else:
+            QMessageBox.information(self, "Plugin Installed", msg)
         worker.deleteLater()
 
     def _on_plugin_install_error(self, message: str, worker: _PluginInstallWorker):


### PR DESCRIPTION
## Summary

- **Removes pandas/openpyxl from the main PyInstaller bundle** — plugin dependencies belong with the plugin, not the core exe
- **Module loader prepends `plugins/<name>/deps/` to `sys.path`** before executing any external plugin, so packages installed there are importable
- **Plugin installer installs deps automatically** after downloading a plugin: reads `requirements.txt`, installs into `deps/` via pip
  - Dev mode: uses `sys.executable` (Python) via subprocess
  - Frozen build: falls back through `python`/`python3`/`py` on PATH, then to `pip._internal.cli.main` (pip bundled with Python — no admin, no system Python required)
- **pip bundled in the spec** via `hiddenimports` so the internal API path works in released builds
- `plugins/*/deps/` added to `.gitignore`
- `jobdocs-report-fixer` already has `requirements.txt` (`pandas>=2.0 openpyxl>=3.1`)

## Test plan
- [ ] Install `jobdocs-report-fixer` via File > Install Plugin — `deps/` should populate and Report Fixer tab loads on restart
- [ ] Reinstall of plugin re-runs pip cleanly
- [ ] Build exe and confirm pandas/openpyxl are no longer in `_internal/`
- [ ] Confirm no admin prompt at any point during install or dep resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin dependencies are now automatically installed during plugin installation. A warning dialog appears if automatic installation fails, providing manual installation instructions.

* **Chores**
  * Updated build configuration to eliminate bundled third-party dependency packaging. Plugins now independently manage their own dependency installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->