### PR TITLE
build: replace PyInstaller with embedded Python for Windows

### DIFF
--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -4321,3 +4321,42 @@ Reviewing files that changed from the base of the PR and between 09700c52e8b62d3
 </details>
 
 <!-- This is an auto-generated comment by CodeRabbit for review status -->
+
+## 2026-04-15 — multiple files (PR #20 — embedded Python build findings)
+
+**Review:** CodeRabbit flagged 4 actionable issues and 3 nitpicks across the embedded-Python build PR.
+**Result:** All 7 fixed in this session.
+
+### Findings
+
+1. **No hash verification on downloaded Python embeddable**
+   - `build-release.yml` downloaded `python-$PY_VER-embed-amd64.zip` without verifying integrity.
+   - Fix applied: pinned `PY_EMBED_SHA256` env var (from python.org sigstore); added `Get-FileHash` check before `Expand-Archive`; fails fast on mismatch.
+
+2. **get-pip.py fetched from network without verification**
+   - Downloading `get-pip.py` from `bootstrap.pypa.io` at build time is an unverified external fetch.
+   - Fix applied: replaced with `python -m pip install --target runtime\Lib\site-packages pip` using the system Python already installed on `windows-latest`, eliminating the external download entirely.
+
+3. **README.md missing from staged app source tree**
+   - `show_readme()` resolves `README.md` relative to `__file__`; it was absent from the `$src_items` copy list so Help → User Guide would fail in packaged builds.
+   - Fix applied: added `'README.md'` to `$src_items` in the Stage app source tree step.
+
+4. **`CreateProcessW` return value not checked in launcher.c**
+   - Failures were silently swallowed; `CloseHandle` was called unconditionally on possibly-invalid handles.
+   - Fix applied: captured BOOL return; on failure calls `GetLastError()`, shows `MessageBoxW` with Python path, script path, and error code, then returns 1. `CloseHandle` is now only reached on success.
+
+5. **Flatpak `/app` is read-only at runtime — `_install_deps` would always fail**
+   - `_install_deps` calls `pip install` using `sys.executable`, which on Flatpak points to a location under read-only `/app`.
+   - Fix applied: added `os.getenv('FLATPAK_ID')` check; returns a clear skip message with manual install command instead of invoking pip.
+
+6. **`AddonPackages/` in .gitignore not anchored to repo root**
+   - Unanchored pattern would silently ignore same-named nested directories.
+   - Fix applied: changed to `/AddonPackages/`.
+
+7. **`launcher.rc` version hardcoded to `0.6.0.0`**
+   - EXE file properties would disagree with the installer/release tag after a version bump.
+   - Fix applied: added preprocessor macros (`VERSION_MAJOR/MINOR/PATCH/BUILD`) with fallback defaults; updated `FILEVERSION`, `PRODUCTVERSION`, and string values to use `VER_STRING` macro; `build-release.yml` Compile Launcher step now parses `github.ref_name` and passes `-D VERSION_*` to windres.
+
+8. **Stale comment in `JobDocs.spec` described removed `deps/`+`sys.path` plugin model**
+   - Comment referenced the old `pip install --target deps/` flow that no longer exists.
+   - Fix applied: reworded to describe current model (pip install into running Python environment).

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -4931,3 +4931,16 @@ Reviewing files that changed from the base of the PR and between 7e62ebbabe8bca4
 </details>
 
 <!-- This is an auto-generated comment by CodeRabbit for review status -->
+
+---
+
+## 2026-04-15 — `main.py` (PR #20 review run 4 — unnecessary f-strings)
+
+**Review:** 1 nitpick (Ruff F541).
+**Result:** Fixed.
+
+### Findings
+
+1. **F-strings with no placeholders (Ruff F541)**
+   - Flatpak return block used `f"..."` on two lines that contain no `{}` interpolation.
+   - Fix applied: removed `f` prefixes; plain string literals.

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -4077,3 +4077,247 @@ Reviewing files that changed from the base of the PR and between 09700c52e8b62d3
 3. **Frozen mode: try bundled pip before system Python**
    - System Python may have a different ABI than the bundled Python, causing binary wheels to be incompatible.
    - Fix applied: in frozen mode, attempt `pip._internal.cli.main` first; fall back to `python`/`py` on PATH only after that fails.
+
+---
+
+## 2026-04-14 — `PR #20: build: replace PyInstaller with embedded Python for Windows` — review run 1
+
+**Actionable comments posted: 4**
+
+<details>
+<summary>🧹 Nitpick comments (3)</summary><blockquote>
+
+<details>
+<summary>.gitignore (1)</summary><blockquote>
+
+`54-54`: **Consider anchoring `AddonPackages/` to repo root.**
+
+If this is only meant for the root-level dev symlink, use `/AddonPackages/` to avoid unintentionally ignoring same-named nested directories.  
+
+<details>
+<summary>Diff suggestion</summary>
+
+```diff
+-AddonPackages/
++/AddonPackages/
+```
+</details>
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In @.gitignore at line 54, The .gitignore entry "AddonPackages/" should be
+anchored to the repository root to avoid ignoring same-named nested directories;
+replace "AddonPackages/" with "/AddonPackages/" (i.e., update the AddonPackages/
+pattern to start with a leading slash) so it only ignores the root-level dev
+symlink.
+```
+
+</details>
+
+</blockquote></details>
+<details>
+<summary>build_scripts/JobDocs.spec (1)</summary><blockquote>
+
+`156-166`: **Refresh this note to match the current plugin install model.**
+
+This block still describes the removed `deps/` + `sys.path` flow, but `main.py` now shells out to `python -m pip install -r ...` into the active environment. Leaving the old description here will send the next person debugging packaging down the wrong path.
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In `@build_scripts/JobDocs.spec` around lines 156 - 166, Update the comment block
+that currently references the removed "deps/" folder and "sys.path" manipulation
+to reflect the new plugin install model: replace the description about plugins
+managing deps in a deps/ subfolder and the module loader prepending sys.path
+with a note that main.py now shells out to "python -m pip install -r
+<requirements.txt>" into the active environment (i.e., installs into the running
+Python environment), and remove or reword any instructions that suggest using
+pip --target deps/ or modifying sys.path so future debuggers are directed to
+check main.py's shell-out install behavior instead.
+```
+
+</details>
+
+</blockquote></details>
+<details>
+<summary>launcher/launcher.rc (1)</summary><blockquote>
+
+`11-12`: **Drive the EXE version metadata from the build, not a literal.**
+
+The installer version already comes from `RELEASE_VERSION`, but the launcher resource is pinned to `0.6.0.0`. The next tag will ship an EXE whose file properties disagree with the installer and release asset name unless this is updated by hand. 
+
+
+Also applies to: 25-30
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In `@launcher/launcher.rc` around lines 11 - 12, The FILEVERSION and
+PRODUCTVERSION entries in launcher.rc are hard-coded to 0,6,0,0; change
+launcher.rc to derive these values from the build/release variables (e.g.,
+RELEASE_VERSION or build-time VERSION macros) instead of literals so the EXE
+metadata matches the installer and release tag—replace the numeric literals used
+in FILEVERSION and PRODUCTVERSION (and the corresponding version strings around
+lines 25-30) with preprocessor-expanded tokens or injected variables (e.g.,
+VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH, VERSION_BUILD or a single
+RELEASE_VERSION split into components) so the resource gets populated at build
+time.
+```
+
+</details>
+
+</blockquote></details>
+
+</blockquote></details>
+
+<details>
+<summary>🤖 Prompt for all review comments with AI agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+Inline comments:
+In @.github/workflows/build-release.yml:
+- Around line 48-65: The workflow currently downloads the Python embeddable ZIP
+and a floating get-pip.py without verification; update the three steps
+("Download Python embeddable", "Enable site-packages in embedded Python",
+"Bootstrap pip into embedded Python") to validate payloads before use by pinning
+expected hashes and failing on mismatch: add variables for the expected SHA256
+for the embeddable ZIP and for get-pip.py, after Invoke-WebRequest compute
+Get-FileHash on the downloaded files and compare to the pinned values (fail/exit
+when they differ), or alternatively vendor the get-pip.py into the repo and
+reference it instead of fetching, and only then run Expand-Archive and
+runtime\python.exe get-pip.py; ensure the workflow treats any checksum mismatch
+as a hard error so release artifacts never use unverified remote payloads.
+- Around line 71-80: The staging step omits README.md so show_readme() (which
+expects README.md next to main.py) will fail in the packaged app; update the
+$src_items array in the "Stage app source tree" PowerShell step to include
+'README.md' alongside 'main.py','core','modules','shared', etc., so README.md is
+copied into the app directory during the build.
+
+In `@launcher/launcher.c`:
+- Around line 51-66: CreateProcessW is currently called but its BOOL return
+value isn't checked, so failures are swallowed and CloseHandle is
+unconditionally called on possibly invalid handles; update the code around
+CreateProcessW to capture its return (e.g., BOOL created = CreateProcessW(...)),
+if created == FALSE call GetLastError(), format or include that error code/text
+and show a user-visible error (e.g., MessageBoxW with a descriptive message
+referencing python/cmdline/exe_path) and return non-zero (e.g., return 1); only
+call CloseHandle on pi.hProcess and pi.hThread when they are valid
+(non-NULL/INVALID_HANDLE_VALUE) to avoid closing invalid handles. Ensure you
+reference CreateProcessW, pi, si, python, cmdline, and exe_path when
+implementing the checks and message.
+
+In `@main.py`:
+- Around line 45-69: The packaged Flatpak build writes plugins under a read-only
+/app so pip installs from _install_deps will fail; update either
+_get_plugins_dir or _install_deps to avoid attempting installs into /app: detect
+Flatpak (e.g., via os.getenv('FLATPAK_ID') or by checking if plugin_dir is under
+'/app' or not writable) and then (a) return a per-user writable path (use
+XDG_DATA_HOME or "~/.var/app/<FLATPAK_ID>/plugins") from _get_plugins_dir, or
+(b) in _install_deps short-circuit and return a clear non-empty warning string
+when plugin_dir is not writable/read-only so pip is not invoked. Reference the
+_get_plugins_dir and _install_deps functions when making the change.
+
+---
+
+Nitpick comments:
+In @.gitignore:
+- Line 54: The .gitignore entry "AddonPackages/" should be anchored to the
+repository root to avoid ignoring same-named nested directories; replace
+"AddonPackages/" with "/AddonPackages/" (i.e., update the AddonPackages/ pattern
+to start with a leading slash) so it only ignores the root-level dev symlink.
+
+In `@build_scripts/JobDocs.spec`:
+- Around line 156-166: Update the comment block that currently references the
+removed "deps/" folder and "sys.path" manipulation to reflect the new plugin
+install model: replace the description about plugins managing deps in a deps/
+subfolder and the module loader prepending sys.path with a note that main.py now
+shells out to "python -m pip install -r <requirements.txt>" into the active
+environment (i.e., installs into the running Python environment), and remove or
+reword any instructions that suggest using pip --target deps/ or modifying
+sys.path so future debuggers are directed to check main.py's shell-out install
+behavior instead.
+
+In `@launcher/launcher.rc`:
+- Around line 11-12: The FILEVERSION and PRODUCTVERSION entries in launcher.rc
+are hard-coded to 0,6,0,0; change launcher.rc to derive these values from the
+build/release variables (e.g., RELEASE_VERSION or build-time VERSION macros)
+instead of literals so the EXE metadata matches the installer and release
+tag—replace the numeric literals used in FILEVERSION and PRODUCTVERSION (and the
+corresponding version strings around lines 25-30) with preprocessor-expanded
+tokens or injected variables (e.g., VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH,
+VERSION_BUILD or a single RELEASE_VERSION split into components) so the resource
+gets populated at build time.
+```
+
+</details>
+
+<details>
+<summary>🪄 Autofix (Beta)</summary>
+
+Fix all unresolved CodeRabbit comments on this PR:
+
+- [ ] <!-- {"checkboxId": "4b0d0e0a-96d7-4f10-b296-3a18ea78f0b9"} --> Push a commit to this branch (recommended)
+- [ ] <!-- {"checkboxId": "ff5b1114-7d8c-49e6-8ac1-43f82af23a33"} --> Create a new PR with the fixes
+
+</details>
+
+---
+
+<details>
+<summary>ℹ️ Review info</summary>
+
+<details>
+<summary>⚙️ Run configuration</summary>
+
+**Configuration used**: Path: .coderabbit.yaml
+
+**Review profile**: CHILL
+
+**Plan**: Pro
+
+**Run ID**: `0a409c05-78dd-4c0c-b826-fd7a77d7ea94`
+
+</details>
+
+<details>
+<summary>📥 Commits</summary>
+
+Reviewing files that changed from the base of the PR and between 09700c52e8b62d3c6ea0ded20e7f767f2741e370 and 0497fc59fac356810658f46cc56a54a059f686f6.
+
+</details>
+
+<details>
+<summary>⛔ Files ignored due to path filters (1)</summary>
+
+* `.claude/S&P.md` is excluded by `!.claude/S&P.md`
+
+</details>
+
+<details>
+<summary>📒 Files selected for processing (7)</summary>
+
+* `.github/workflows/build-release.yml`
+* `.gitignore`
+* `build_scripts/JobDocs.iss`
+* `build_scripts/JobDocs.spec`
+* `launcher/launcher.c`
+* `launcher/launcher.rc`
+* `main.py`
+
+</details>
+
+</details>
+
+<!-- This is an auto-generated comment by CodeRabbit for review status -->

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -4547,3 +4547,102 @@ Reviewing files that changed from the base of the PR and between 0497fc59fac3568
    - `python -m pip install ... pip` pulls whatever pip PyPI serves on build day.
    - System `python` comes from the mutable `windows-latest` image.
    - Fix applied: added `actions/setup-python@v5` step (pinned to `python-version: '3.12'`); pinned pip to `pip==24.3.1` in the install command.
+
+---
+
+## 2026-04-15 — `PR #20: build: replace PyInstaller with embedded Python for Windows` — review run 2
+
+**Actionable comments posted: 2**
+
+<details>
+<summary>🤖 Prompt for all review comments with AI agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+Inline comments:
+In `@main.py`:
+- Around line 580-585: The success message in _on_plugin_install_success
+incorrectly promises the plugin will load even when dep_warning is set; update
+the messaging so that when dep_warning is truthy (requirements skipped/failed)
+the dialog text says the plugin files were copied but the plugin may not load
+until dependencies are resolved and include the dep_warning details (use
+QMessageBox.warning with msg + dep_warning), while when dep_warning is falsy
+keep the original "Restart JobDocs to load it." wording (use
+QMessageBox.information); reference function _on_plugin_install_success and
+variables module_name, dest, dep_warning to locate and change the conditional
+message text accordingly.
+- Around line 57-76: The two user-facing instructions advising "pip install -r
+\"{req_file}\"" should be changed to recommend invoking pip with the current
+interpreter to avoid PATH/venv confusion; update the Flatpak message and the
+failure message to instruct users to run the installer via sys.executable (e.g.
+use the interpreter-qualified form: <sys.executable> -m pip install -r
+"{req_file}") so the guidance is accurate; locate the strings near the Flatpak
+branch (uses os.getenv('FLATPAK_ID') and req_file) and the subprocess
+error-handling block (uses subprocess.run, result.returncode, and err) and
+replace the bare "pip install -r ..." instructions with the
+interpreter-qualified form using sys.executable.
+```
+
+</details>
+
+<details>
+<summary>🪄 Autofix (Beta)</summary>
+
+Fix all unresolved CodeRabbit comments on this PR:
+
+- [ ] <!-- {"checkboxId": "4b0d0e0a-96d7-4f10-b296-3a18ea78f0b9"} --> Push a commit to this branch (recommended)
+- [ ] <!-- {"checkboxId": "ff5b1114-7d8c-49e6-8ac1-43f82af23a33"} --> Create a new PR with the fixes
+
+</details>
+
+---
+
+<details>
+<summary>ℹ️ Review info</summary>
+
+<details>
+<summary>⚙️ Run configuration</summary>
+
+**Configuration used**: Path: .coderabbit.yaml
+
+**Review profile**: CHILL
+
+**Plan**: Pro
+
+**Run ID**: `531f725e-fb26-4374-a1a5-b6a39b9ab6b7`
+
+</details>
+
+<details>
+<summary>📥 Commits</summary>
+
+Reviewing files that changed from the base of the PR and between 1c57a11293dbb3c97308bfde1dbe07726654b5fb and 3168a7d190279d965f118367178a6ea8b9b17017.
+
+</details>
+
+<details>
+<summary>⛔ Files ignored due to path filters (1)</summary>
+
+* `.claude/S&P.md` is excluded by `!.claude/S&P.md`
+
+</details>
+
+<details>
+<summary>📒 Files selected for processing (2)</summary>
+
+* `.github/workflows/build-release.yml`
+* `main.py`
+
+</details>
+
+<details>
+<summary>🚧 Files skipped from review as they are similar to previous changes (1)</summary>
+
+* .github/workflows/build-release.yml
+
+</details>
+
+</details>
+
+<!-- This is an auto-generated comment by CodeRabbit for review status -->

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -3965,3 +3965,93 @@ Reviewing files that changed from the base of the PR and between ce304ec214964c6
 </details>
 
 <!-- This is an auto-generated comment by CodeRabbit for review status -->
+
+---
+
+## 2026-04-14 — `PR #19: fix: isolate plugin deps into plugin-local deps/ directory` — review run 1
+
+**Actionable comments posted: 4**
+
+<details>
+<summary>🤖 Prompt for all review comments with AI agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+Inline comments:
+In `@main.py`:
+- Around line 55-57: The current creation of deps_dir and subsequent pip install
+into that path (variable deps_dir) can leave stale/partial packages; change the
+flow to create a fresh temporary directory (e.g., temp_deps_dir), run pip
+install --target into that temp directory, verify success, then atomically
+replace/move temp_deps_dir to deps_dir (remove or backup existing deps_dir only
+after successful install) to avoid overlaying and leftover files—apply the same
+pattern for the other install sites referenced around the blocks using deps_dir
+(lines noted 72-77 and 91-92) so installs are always performed into a clean temp
+folder and swapped into place on success.
+- Around line 103-106: The returned error message omits the --target flag so
+users run pip globally; update the string construction that returns the manual
+recovery command to include the plugin-local target by adding --target
+"{deps_dir}" (use the existing deps_dir variable alongside req_file and
+last_err) so the suggested command is pip install --target "{deps_dir}" -r
+"{req_file}" and preserve the existing error text fallback (last_err or 'no
+usable Python found on PATH').
+- Around line 61-67: When sys.frozen is true the code currently appends system
+Python names into candidates before ever trying the embedded pip, causing wheels
+to be chosen for the system ABI; change the candidates construction so that when
+getattr(sys, 'frozen', False) is True you try the bundled pip API
+(pip._internal) first and only then extend with ['python','python3','py'] as a
+last resort—i.e., ensure the candidates list contains a pip._internal attempt
+first in frozen mode and falls back to the system Python names otherwise.
+```
+
+</details>
+
+<details>
+<summary>🪄 Autofix (Beta)</summary>
+
+Fix all unresolved CodeRabbit comments on this PR:
+
+- [ ] <!-- {"checkboxId": "4b0d0e0a-96d7-4f10-b296-3a18ea78f0b9"} --> Push a commit to this branch (recommended)
+- [ ] <!-- {"checkboxId": "ff5b1114-7d8c-49e6-8ac1-43f82af23a33"} --> Create a new PR with the fixes
+
+</details>
+
+---
+
+<details>
+<summary>ℹ️ Review info</summary>
+
+<details>
+<summary>⚙️ Run configuration</summary>
+
+**Configuration used**: Path: .coderabbit.yaml
+
+**Review profile**: CHILL
+
+**Plan**: Pro
+
+**Run ID**: `564b50cc-67cd-49b3-b031-57621bf81fa5`
+
+</details>
+
+<details>
+<summary>📥 Commits</summary>
+
+Reviewing files that changed from the base of the PR and between 09700c52e8b62d3c6ea0ded20e7f767f2741e370 and f00a384bba3632eca3a8fda3be7bb02ee247a6d7.
+
+</details>
+
+<details>
+<summary>📒 Files selected for processing (4)</summary>
+
+* `.gitignore`
+* `build_scripts/JobDocs.spec`
+* `core/module_loader.py`
+* `main.py`
+
+</details>
+
+</details>
+
+<!-- This is an auto-generated comment by CodeRabbit for review status -->

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -4360,3 +4360,171 @@ Reviewing files that changed from the base of the PR and between 09700c52e8b62d3
 8. **Stale comment in `JobDocs.spec` described removed `deps/`+`sys.path` plugin model**
    - Comment referenced the old `pip install --target deps/` flow that no longer exists.
    - Fix applied: reworded to describe current model (pip install into running Python environment).
+
+---
+
+## 2026-04-15 — `PR #20: build: replace PyInstaller with embedded Python for Windows` — review run 1
+
+
+
+<details>
+<summary>♻️ Duplicate comments (2)</summary><blockquote>
+
+<details>
+<summary>main.py (1)</summary><blockquote>
+
+`399-414`: _⚠️ Potential issue_ | _🟠 Major_
+
+**Flatpak still resolves plugins into the bundled app tree.**
+
+This only distinguishes the embedded-Windows layout from source layout. The Linux release is still a Flatpak, so `_get_plugins_dir()` will resolve next to the frozen bundle, and `_PluginInstallWorker` then tries to create/copy plugin files there before `_install_deps()` runs. In Flatpak, the app bundle under `/app` is read-only, while per-user data belongs under `$XDG_DATA_HOME` / `~/.var/app/$FLATPAK_ID/data`, so plugin install remains broken on Linux. Return a per-user writable path when `FLATPAK_ID` is set, or disable plugin installation in that mode. ([docs.flatpak.org](https://docs.flatpak.org/zh-cn/latest/sandbox-permissions.html?utm_source=openai))
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In `@main.py` around lines 399 - 414, The _get_plugins_dir function currently only
+switches between embedded and source layouts and can resolve to the read-only
+Flatpak bundle; update _get_plugins_dir to detect Flatpak by checking the
+FLATPAK_ID environment variable and return a writable per-user plugins path
+(prefer XDG_DATA_HOME/plugins or fallback to
+~/.var/app/{FLATPAK_ID}/data/plugins) when FLATPAK_ID is set, or alternatively
+return None/raise so _PluginInstallWorker/_install_deps know to skip plugin
+installation in Flatpak mode; ensure references to _PluginInstallWorker and
+_install_deps handle the new None/skip behavior if you choose that route.
+```
+
+</details>
+
+</blockquote></details>
+<details>
+<summary>.github/workflows/build-release.yml (1)</summary><blockquote>
+
+`35-76`: _⚠️ Potential issue_ | _🟠 Major_
+
+**Pin the pip bootstrap input.**
+
+`python -m pip install --target ... pip` still pulls whatever stable `pip` release PyPI serves on build day, and the `python` binary itself comes from the mutable `windows-latest` image. That makes the Windows installer drift over time even when the repo hasn’t changed. Please bootstrap from a pinned wheel or at least a pinned `pip==...` plus hash, and use a specific runner/interpreter for that download step. GitHub notes that `-latest` images migrate over time and recommends `actions/setup-python` for consistent behavior; pip installs stable releases by default when no version is specified. ([github.com](https://github.com/actions/runner-images?utm_source=openai))
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In @.github/workflows/build-release.yml around lines 35 - 76, The bootstrap step
+in the build-windows job currently runs "python -m pip install --target
+runtime\Lib\site-packages --no-deps pip" without a pinned pip version or hash
+and relies on the mutable windows-latest image; change the "Bootstrap pip into
+embedded Python" step so it installs a specific pip release (e.g. pip==23.2.1)
+with a pinned hash or installs from a vendored wheel file instead of an unpinned
+PyPI install, and ensure the runner/interpreter is fixed by adding or using
+actions/setup-python to pin the Python runtime before running
+runtime\python.exe; update the commands referenced (the install invocation and
+the runtime\python.exe -m pip --version check) to reflect the pinned artifact
+and verify its checksum.
+```
+
+</details>
+
+</blockquote></details>
+
+</blockquote></details>
+
+<details>
+<summary>🤖 Prompt for all review comments with AI agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+Duplicate comments:
+In @.github/workflows/build-release.yml:
+- Around line 35-76: The bootstrap step in the build-windows job currently runs
+"python -m pip install --target runtime\Lib\site-packages --no-deps pip" without
+a pinned pip version or hash and relies on the mutable windows-latest image;
+change the "Bootstrap pip into embedded Python" step so it installs a specific
+pip release (e.g. pip==23.2.1) with a pinned hash or installs from a vendored
+wheel file instead of an unpinned PyPI install, and ensure the
+runner/interpreter is fixed by adding or using actions/setup-python to pin the
+Python runtime before running runtime\python.exe; update the commands referenced
+(the install invocation and the runtime\python.exe -m pip --version check) to
+reflect the pinned artifact and verify its checksum.
+
+In `@main.py`:
+- Around line 399-414: The _get_plugins_dir function currently only switches
+between embedded and source layouts and can resolve to the read-only Flatpak
+bundle; update _get_plugins_dir to detect Flatpak by checking the FLATPAK_ID
+environment variable and return a writable per-user plugins path (prefer
+XDG_DATA_HOME/plugins or fallback to ~/.var/app/{FLATPAK_ID}/data/plugins) when
+FLATPAK_ID is set, or alternatively return None/raise so
+_PluginInstallWorker/_install_deps know to skip plugin installation in Flatpak
+mode; ensure references to _PluginInstallWorker and _install_deps handle the new
+None/skip behavior if you choose that route.
+```
+
+</details>
+
+---
+
+<details>
+<summary>ℹ️ Review info</summary>
+
+<details>
+<summary>⚙️ Run configuration</summary>
+
+**Configuration used**: Path: .coderabbit.yaml
+
+**Review profile**: CHILL
+
+**Plan**: Pro
+
+**Run ID**: `c3f34243-fac6-441b-9efe-a9835341f695`
+
+</details>
+
+<details>
+<summary>📥 Commits</summary>
+
+Reviewing files that changed from the base of the PR and between 0497fc59fac356810658f46cc56a54a059f686f6 and 1c57a11293dbb3c97308bfde1dbe07726654b5fb.
+
+</details>
+
+<details>
+<summary>⛔ Files ignored due to path filters (1)</summary>
+
+* `.claude/S&P.md` is excluded by `!.claude/S&P.md`
+
+</details>
+
+<details>
+<summary>📒 Files selected for processing (6)</summary>
+
+* `.github/workflows/build-release.yml`
+* `.gitignore`
+* `build_scripts/JobDocs.spec`
+* `launcher/launcher.c`
+* `launcher/launcher.rc`
+* `main.py`
+
+</details>
+
+<details>
+<summary>✅ Files skipped from review due to trivial changes (2)</summary>
+
+* .gitignore
+* launcher/launcher.rc
+
+</details>
+
+<details>
+<summary>🚧 Files skipped from review as they are similar to previous changes (1)</summary>
+
+* build_scripts/JobDocs.spec
+
+</details>
+
+</details>
+
+<!-- This is an auto-generated comment by CodeRabbit for review status -->

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -4819,3 +4819,115 @@ Reviewing files that changed from the base of the PR and between 3168a7d190279d9
 3. **Docstring contains invalid escape `runtime\python.exe`**
    - Bare backslash in a regular (non-raw) docstring is an invalid escape sequence.
    - Fix applied: escaped as `runtime\python.exe`.
+
+---
+
+## 2026-04-15 — `PR #20: build: replace PyInstaller with embedded Python for Windows` — review run 4
+
+
+
+<details>
+<summary>🧹 Nitpick comments (1)</summary><blockquote>
+
+<details>
+<summary>main.py (1)</summary><blockquote>
+
+`60-63`: **Remove extraneous `f` prefixes from strings without placeholders.**
+
+Lines 61 and 62 are f-strings but contain no interpolation placeholders. This is flagged by Ruff (F541).
+
+
+<details>
+<summary>Suggested fix</summary>
+
+```diff
+         if os.getenv('FLATPAK_ID'):
+             return (
+-                f"\n\nDependency installation is not supported inside a Flatpak build.\n"
+-                f"Install the plugin's dependencies on the host system before use."
++                "\n\nDependency installation is not supported inside a Flatpak build.\n"
++                "Install the plugin's dependencies on the host system before use."
+             )
+```
+</details>
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In `@main.py` around lines 60 - 63, The returned multiline string uses unnecessary
+f-strings (no interpolation) which triggers Ruff F541; remove the leading f
+prefixes from the two string literals in the return expression (the strings
+beginning with "Dependency installation is not supported inside a Flatpak
+build." and "Install the plugin's dependencies on the host system before use.")
+so they are plain string literals instead of f-strings.
+```
+
+</details>
+
+</blockquote></details>
+
+</blockquote></details>
+
+<details>
+<summary>🤖 Prompt for all review comments with AI agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+Nitpick comments:
+In `@main.py`:
+- Around line 60-63: The returned multiline string uses unnecessary f-strings
+(no interpolation) which triggers Ruff F541; remove the leading f prefixes from
+the two string literals in the return expression (the strings beginning with
+"Dependency installation is not supported inside a Flatpak build." and "Install
+the plugin's dependencies on the host system before use.") so they are plain
+string literals instead of f-strings.
+```
+
+</details>
+
+---
+
+<details>
+<summary>ℹ️ Review info</summary>
+
+<details>
+<summary>⚙️ Run configuration</summary>
+
+**Configuration used**: Path: .coderabbit.yaml
+
+**Review profile**: CHILL
+
+**Plan**: Pro
+
+**Run ID**: `e1a7e1e5-a2d9-4ecc-a984-81119a45eb2e`
+
+</details>
+
+<details>
+<summary>📥 Commits</summary>
+
+Reviewing files that changed from the base of the PR and between 7e62ebbabe8bca488cef703a55a2b26858329033 and 1c2ff7c951b829c8963cab8faf1f6fa4e0f2bedb.
+
+</details>
+
+<details>
+<summary>⛔ Files ignored due to path filters (1)</summary>
+
+* `.claude/S&P.md` is excluded by `!.claude/S&P.md`
+
+</details>
+
+<details>
+<summary>📒 Files selected for processing (1)</summary>
+
+* `main.py`
+
+</details>
+
+</details>
+
+<!-- This is an auto-generated comment by CodeRabbit for review status -->

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -4528,3 +4528,22 @@ Reviewing files that changed from the base of the PR and between 0497fc59fac3568
 </details>
 
 <!-- This is an auto-generated comment by CodeRabbit for review status -->
+
+---
+
+## 2026-04-15 — `main.py` + `build-release.yml` (PR #20 duplicate findings — Flatpak plugins dir & pip pinning)
+
+**Review:** CodeRabbit flagged 2 issues as duplicate comments (carried forward from first review pass, not fully resolved by `1c57a11`).
+**Result:** Both fixed.
+
+### Findings
+
+1. **`_get_plugins_dir()` resolves into read-only Flatpak bundle**
+   - On Flatpak, `__file__` is under `/app` which is read-only at runtime.
+   - `_get_plugins_dir()` would return `/app/plugins`, causing plugin install to fail silently.
+   - Fix applied: check `FLATPAK_ID` env var; if set, return `$XDG_DATA_HOME/plugins` (or `~/.var/app/{FLATPAK_ID}/data/plugins` as fallback).
+
+2. **pip bootstrap in `build-release.yml` uses unpinned version with mutable system Python**
+   - `python -m pip install ... pip` pulls whatever pip PyPI serves on build day.
+   - System `python` comes from the mutable `windows-latest` image.
+   - Fix applied: added `actions/setup-python@v5` step (pinned to `python-version: '3.12'`); pinned pip to `pip==24.3.1` in the install command.

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -4663,3 +4663,138 @@ Reviewing files that changed from the base of the PR and between 1c57a11293dbb3c
 2. **`_on_plugin_install_success` promises "Restart to load it" even when deps failed**
    - When `dep_warning` is set, the base message still said "Restart JobDocs to load it." — misleading because the plugin may not actually load without its dependencies.
    - Fix applied: when `dep_warning` is truthy, base message now reads "files copied… may not load until dependencies are resolved" (QMessageBox.warning); only the success path keeps "Restart JobDocs to load it." (QMessageBox.information).
+
+---
+
+## 2026-04-15 — `PR #20: build: replace PyInstaller with embedded Python for Windows` — review run 3
+
+**Actionable comments posted: 2**
+
+<details>
+<summary>♻️ Duplicate comments (1)</summary><blockquote>
+
+<details>
+<summary>main.py (1)</summary><blockquote>
+
+`57-63`: _⚠️ Potential issue_ | _🟠 Major_
+
+**Flatpak still surfaces a recovery command that targets the read-only runtime.**
+
+This branch correctly skips auto-install on Flatpak, but the returned `sys.executable -m pip ...` advice still points users at the same sandboxed interpreter you just deemed unwritable. For dependency-backed plugins, that leaves no working recovery path. Either remove the manual command here and state that manual dependency install is unsupported in Flatpak builds, or switch Flatpak to a supported user-writable install target.
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In `@main.py` around lines 57 - 63, The Flatpak branch currently returns a
+recovery command using sys.executable which points to the read-only runtime;
+update the returned message in the FLATPAK_ID branch to avoid suggesting the
+unwritable runtime. Replace the manual command that uses sys.executable -m pip
+install -r "{req_file}" with either (a) a clear statement that manual dependency
+installation is unsupported inside Flatpak builds (remove the pip command), or
+(b) a supported user-writable alternative such as recommending the host/system
+Python or a user-install target (e.g., "python -m pip install --user -r
+\"{req_file}\"" or instructing to install on the host), and ensure the message
+references req_file but not the sandboxed sys.executable.
+```
+
+</details>
+
+</blockquote></details>
+
+</blockquote></details>
+
+<details>
+<summary>🤖 Prompt for all review comments with AI agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+Inline comments:
+In `@main.py`:
+- Around line 62-63: The printed "Install manually" recovery command uses
+sys.executable without quotes, which breaks on paths containing spaces; update
+both occurrences where the string is constructed (the f-string that includes
+sys.executable and req_file) to wrap sys.executable in quotes (e.g.,
+f'"{sys.executable}" -m pip install -r "{req_file}"') so the copy-paste command
+is safe on Windows; ensure you change both places referenced in the diff (the
+two f-strings that include sys.executable and req_file).
+- Around line 47-50: The docstring in main.py containing "Install plugin
+requirements into the embedded Python's site-packages." includes the sequence
+runtime\python.exe which produces an invalid escape; update that docstring (the
+triple-quoted string starting with "Install plugin requirements...") to either
+escape the backslash as runtime\\python.exe or convert the docstring to a raw
+string (e.g., r"""...""") so the backslash is treated literally.
+
+---
+
+Duplicate comments:
+In `@main.py`:
+- Around line 57-63: The Flatpak branch currently returns a recovery command
+using sys.executable which points to the read-only runtime; update the returned
+message in the FLATPAK_ID branch to avoid suggesting the unwritable runtime.
+Replace the manual command that uses sys.executable -m pip install -r
+"{req_file}" with either (a) a clear statement that manual dependency
+installation is unsupported inside Flatpak builds (remove the pip command), or
+(b) a supported user-writable alternative such as recommending the host/system
+Python or a user-install target (e.g., "python -m pip install --user -r
+\"{req_file}\"" or instructing to install on the host), and ensure the message
+references req_file but not the sandboxed sys.executable.
+```
+
+</details>
+
+<details>
+<summary>🪄 Autofix (Beta)</summary>
+
+Fix all unresolved CodeRabbit comments on this PR:
+
+- [ ] <!-- {"checkboxId": "4b0d0e0a-96d7-4f10-b296-3a18ea78f0b9"} --> Push a commit to this branch (recommended)
+- [ ] <!-- {"checkboxId": "ff5b1114-7d8c-49e6-8ac1-43f82af23a33"} --> Create a new PR with the fixes
+
+</details>
+
+---
+
+<details>
+<summary>ℹ️ Review info</summary>
+
+<details>
+<summary>⚙️ Run configuration</summary>
+
+**Configuration used**: Path: .coderabbit.yaml
+
+**Review profile**: CHILL
+
+**Plan**: Pro
+
+**Run ID**: `b45528b0-9c0e-423e-aec9-9aed4edd0b98`
+
+</details>
+
+<details>
+<summary>📥 Commits</summary>
+
+Reviewing files that changed from the base of the PR and between 3168a7d190279d965f118367178a6ea8b9b17017 and 7e62ebbabe8bca488cef703a55a2b26858329033.
+
+</details>
+
+<details>
+<summary>⛔ Files ignored due to path filters (1)</summary>
+
+* `.claude/S&P.md` is excluded by `!.claude/S&P.md`
+
+</details>
+
+<details>
+<summary>📒 Files selected for processing (1)</summary>
+
+* `main.py`
+
+</details>
+
+</details>
+
+<!-- This is an auto-generated comment by CodeRabbit for review status -->

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -4055,3 +4055,25 @@ Reviewing files that changed from the base of the PR and between 09700c52e8b62d3
 </details>
 
 <!-- This is an auto-generated comment by CodeRabbit for review status -->
+
+---
+
+## 2026-04-14 — `main.py` (plugin dep installer — PR #19 findings)
+
+**Review:** CodeRabbit flagged three actionable issues in `_install_deps`.
+**Result:** All three fixed in commit `dad24fb`.
+
+### Findings
+
+1. **Atomic install via temp directory**
+   - Pip into `deps.tmp/` first, then backup-then-swap into `deps/` on success.
+   - Prevents stale/partial packages if install fails mid-way.
+   - Fix applied: backup-then-swap pattern identical to plugin install in `run()`.
+
+2. **Manual recovery command missing `--target`**
+   - Error message said `pip install -r req_file`, which installs globally.
+   - Fix applied: changed to `pip install --target "{deps_dir}" -r "{req_file}"`.
+
+3. **Frozen mode: try bundled pip before system Python**
+   - System Python may have a different ABI than the bundled Python, causing binary wheels to be incompatible.
+   - Fix applied: in frozen mode, attempt `pip._internal.cli.main` first; fall back to `python`/`py` on PATH only after that fails.

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -4798,3 +4798,24 @@ Reviewing files that changed from the base of the PR and between 3168a7d190279d9
 </details>
 
 <!-- This is an auto-generated comment by CodeRabbit for review status -->
+
+---
+
+## 2026-04-15 — `main.py` (PR #20 review run 3 — Flatpak recovery command & quoting)
+
+**Review:** CodeRabbit flagged 2 actionable issues (1 duplicate + 1 new inline) and 1 nitpick in `_install_deps`.
+**Result:** All 3 fixed.
+
+### Findings
+
+1. **Flatpak recovery command points at read-only `sys.executable`**
+   - After using `sys.executable` in the Flatpak skip message, CodeRabbit noted that `sys.executable` IS the sandboxed read-only runtime — so the manual command was also unworkable.
+   - Fix applied: removed the pip command entirely; message now states "dependency installation is not supported inside a Flatpak build."
+
+2. **`sys.executable` not quoted in failure recovery command**
+   - Paths containing spaces (e.g. `C:\Program Files\...`) would break the copy-paste command.
+   - Fix applied: wrapped as `"{sys.executable}"` in the failure message f-string.
+
+3. **Docstring contains invalid escape `runtime\python.exe`**
+   - Bare backslash in a regular (non-raw) docstring is an invalid escape sequence.
+   - Fix applied: escaped as `runtime\python.exe`.

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -4646,3 +4646,20 @@ Reviewing files that changed from the base of the PR and between 1c57a11293dbb3c
 </details>
 
 <!-- This is an auto-generated comment by CodeRabbit for review status -->
+
+---
+
+## 2026-04-15 — `main.py` (PR #20 review run 2 — pip instructions & dep-warning message)
+
+**Review:** CodeRabbit flagged 2 actionable issues in `_install_deps` and `_on_plugin_install_success`.
+**Result:** Both fixed.
+
+### Findings
+
+1. **Manual pip recovery commands use bare `pip` instead of `sys.executable`**
+   - Both the Flatpak skip message and the subprocess failure message advised `pip install -r ...`, which resolves to whatever `pip` is first on PATH and may target the wrong interpreter/venv.
+   - Fix applied: changed to `{sys.executable} -m pip install -r "{req_file}"` in both strings.
+
+2. **`_on_plugin_install_success` promises "Restart to load it" even when deps failed**
+   - When `dep_warning` is set, the base message still said "Restart JobDocs to load it." — misleading because the plugin may not actually load without its dependencies.
+   - Fix applied: when `dep_warning` is truthy, base message now reads "files copied… may not load until dependencies are resolved" (QMessageBox.warning); only the success path keeps "Restart JobDocs to load it." (QMessageBox.information).

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -40,6 +40,9 @@ jobs:
 
     env:
       PY_VER: "3.12.9"
+      # SHA256 of python-3.12.9-embed-amd64.zip (verified via python.org sigstore)
+      # Update this value whenever PY_VER is bumped.
+      PY_EMBED_SHA256: "615861fb801e8b04c847598db4e1e46e4b046295017caa37cb5486dde72b5865"
 
     steps:
       - name: Checkout
@@ -50,6 +53,11 @@ jobs:
         run: |
           $url = "https://www.python.org/ftp/python/$env:PY_VER/python-$env:PY_VER-embed-amd64.zip"
           Invoke-WebRequest $url -OutFile python-embed.zip
+          $actual = (Get-FileHash python-embed.zip -Algorithm SHA256).Hash.ToLower()
+          if ($actual -ne $env:PY_EMBED_SHA256) {
+            Write-Error "SHA256 mismatch for python-embed.zip`nExpected: $env:PY_EMBED_SHA256`nActual:   $actual"
+            exit 1
+          }
           Expand-Archive python-embed.zip -DestinationPath runtime
 
       - name: Enable site-packages in embedded Python
@@ -57,12 +65,15 @@ jobs:
         run: |
           $pth = Get-Item runtime\python3*._pth
           (Get-Content $pth) -replace '#import site', 'import site' | Set-Content $pth
+          New-Item -ItemType Directory -Path runtime\Lib\site-packages -Force | Out-Null
 
       - name: Bootstrap pip into embedded Python
         shell: pwsh
         run: |
-          Invoke-WebRequest https://bootstrap.pypa.io/get-pip.py -OutFile get-pip.py
-          runtime\python.exe get-pip.py --no-warn-script-location
+          # Use the system pip (pre-installed on windows-latest) rather than
+          # downloading get-pip.py from the network, avoiding an unverified fetch.
+          python -m pip install --target runtime\Lib\site-packages --no-deps pip
+          runtime\python.exe -m pip --version
 
       - name: Install app dependencies into embedded Python
         run: runtime\python.exe -m pip install -r requirements.txt --no-warn-script-location
@@ -71,7 +82,7 @@ jobs:
       - name: Stage app source tree
         shell: pwsh
         run: |
-          $src_items = @('main.py','core','modules','shared',
+          $src_items = @('main.py','README.md','core','modules','shared',
                          'JobDocs.iconset','sample_files','requirements.txt')
           New-Item -ItemType Directory -Path app -Force | Out-Null
           foreach ($item in $src_items) {
@@ -83,7 +94,13 @@ jobs:
       - name: Compile launcher (MinGW)
         shell: bash
         run: |
-          windres launcher/launcher.rc -O coff -o launcher_res.o
+          VER="${{ github.ref_name }}"
+          VER="${VER#v}"
+          IFS='.' read -r MAJOR MINOR PATCH rest <<< "$VER"
+          MAJOR=${MAJOR:-0}; MINOR=${MINOR:-0}; PATCH=${PATCH:-0}
+          windres launcher/launcher.rc -O coff -o launcher_res.o \
+            -D VERSION_MAJOR="$MAJOR" -D VERSION_MINOR="$MINOR" \
+            -D VERSION_PATCH="$PATCH" -D VERSION_BUILD=0
           gcc -mwindows -O2 -o JobDocs.exe launcher/launcher.c launcher_res.o
 
       - name: Verify build

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -48,6 +48,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Python for bootstrapping
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: Download Python embeddable
         shell: pwsh
         run: |
@@ -70,9 +75,10 @@ jobs:
       - name: Bootstrap pip into embedded Python
         shell: pwsh
         run: |
-          # Use the system pip (pre-installed on windows-latest) rather than
+          # Use the setup-python system pip (pinned version above) rather than
           # downloading get-pip.py from the network, avoiding an unverified fetch.
-          python -m pip install --target runtime\Lib\site-packages --no-deps pip
+          # Pin pip version for reproducible builds — bump PIP_VER when upgrading.
+          python -m pip install --target runtime\Lib\site-packages --no-deps "pip==24.3.1"
           runtime\python.exe -m pip --version
 
       - name: Install app dependencies into embedded Python

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -24,7 +24,13 @@ jobs:
           echo "OK: $GITHUB_REF_NAME is descended from stable"
 
   # ---------------------------------------------------------------------------
-  # Windows — PyInstaller onedir build packaged by Inno Setup
+  # Windows — Embedded Python + source files packaged by Inno Setup
+  #
+  # Layout inside the installer:
+  #   {app}\JobDocs.exe        tiny C launcher (no console)
+  #   {app}\app\               Python source tree
+  #   {app}\runtime\           Python 3.12 embeddable + pre-installed deps
+  #   {app}\plugins\           empty; user populates via Install Plugin
   # ---------------------------------------------------------------------------
   build-windows:
     needs: verify-stable-ancestry
@@ -32,38 +38,74 @@ jobs:
     permissions:
       contents: read
 
+    env:
+      PY_VER: "3.12.9"
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install dependencies
+      - name: Download Python embeddable
+        shell: pwsh
         run: |
-          pip install -r requirements.txt
-          pip install "pyinstaller>=6.0.0" "Pillow>=10.4.0,<12.0.0"
+          $url = "https://www.python.org/ftp/python/$env:PY_VER/python-$env:PY_VER-embed-amd64.zip"
+          Invoke-WebRequest $url -OutFile python-embed.zip
+          Expand-Archive python-embed.zip -DestinationPath runtime
 
-      - name: Build executable
-        run: python -m PyInstaller build_scripts/JobDocs.spec --clean --noconfirm
+      - name: Enable site-packages in embedded Python
+        shell: pwsh
+        run: |
+          $pth = Get-Item runtime\python3*._pth
+          (Get-Content $pth) -replace '#import site', 'import site' | Set-Content $pth
+
+      - name: Bootstrap pip into embedded Python
+        shell: pwsh
+        run: |
+          Invoke-WebRequest https://bootstrap.pypa.io/get-pip.py -OutFile get-pip.py
+          runtime\python.exe get-pip.py --no-warn-script-location
+
+      - name: Install app dependencies into embedded Python
+        run: runtime\python.exe -m pip install -r requirements.txt --no-warn-script-location
+        shell: pwsh
+
+      - name: Stage app source tree
+        shell: pwsh
+        run: |
+          $src_items = @('main.py','core','modules','shared',
+                         'JobDocs.iconset','sample_files','requirements.txt')
+          New-Item -ItemType Directory -Path app -Force | Out-Null
+          foreach ($item in $src_items) {
+            if (Test-Path $item) {
+              Copy-Item $item app\ -Recurse -Force
+            }
+          }
+
+      - name: Compile launcher (MinGW)
+        shell: bash
+        run: |
+          windres launcher/launcher.rc -O coff -o launcher_res.o
+          gcc -mwindows -O2 -o JobDocs.exe launcher/launcher.c launcher_res.o
 
       - name: Verify build
-        run: |
-          if (!(Test-Path "dist/JobDocs/JobDocs.exe")) {
-            Write-Error "dist/JobDocs/JobDocs.exe not found — build failed"
-            exit 1
-          }
-          Write-Output "Build OK: $(Get-Item dist/JobDocs/JobDocs.exe | Select-Object -ExpandProperty Length) bytes"
         shell: pwsh
+        run: |
+          if (!(Test-Path "JobDocs.exe")) {
+            Write-Error "JobDocs.exe not found — launcher build failed"; exit 1
+          }
+          if (!(Test-Path "runtime\python.exe")) {
+            Write-Error "runtime\python.exe not found — embed setup failed"; exit 1
+          }
+          if (!(Test-Path "app\main.py")) {
+            Write-Error "app\main.py not found — staging failed"; exit 1
+          }
+          Write-Output "Launcher: $(Get-Item JobDocs.exe | Select-Object -ExpandProperty Length) bytes"
+          Write-Output "Runtime Python: $(runtime\python.exe --version)"
 
       # -----------------------------------------------------------------------
       # SignPath code signing — uncomment once SignPath Foundation is approved
       # Apply at: https://signpath.io/product/open-source
-      # Sign dist/JobDocs/JobDocs.exe before iscc packages it.
       # -----------------------------------------------------------------------
-      # - name: Sign executable
+      # - name: Sign launcher
       #   uses: signpath/github-action-submit-signing-request@v1
       #   with:
       #     api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -75,17 +117,17 @@ jobs:
       #     output-artifact-name: JobDocs-signed
 
       - name: Ensure Inno Setup is available
+        shell: pwsh
         run: |
           if (!(Get-Command iscc -ErrorAction SilentlyContinue)) {
             choco install innosetup --confirm --no-progress
           }
-        shell: pwsh
 
       - name: Build Windows installer
+        shell: pwsh
         run: |
           $env:RELEASE_VERSION = "${{ github.ref_name }}"
           iscc build_scripts\JobDocs.iss
-        shell: pwsh
 
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -48,8 +48,9 @@ Thumbs.db
 test_output/
 old/
 
-# Plugin-installed dependencies (managed at runtime, not checked in)
-plugins/*/deps/
+# Shared addon packages dir (managed at runtime via pip, not checked in)
+# Lives in %LOCALAPPDATA%\JobDocs\AddonPackages\ — dev symlink if present
+AddonPackages/
 
 # Flatpak — staged binary and icon (copied from build_dist/ by CI, not source files)
 linux/flatpak/JobDocs

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ Thumbs.db
 test_output/
 old/
 
+# Plugin-installed dependencies (managed at runtime, not checked in)
+plugins/*/deps/
+
 # Flatpak — staged binary and icon (copied from build_dist/ by CI, not source files)
 linux/flatpak/JobDocs
 linux/flatpak/icon_256x256.png

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@ itar/
 not itar/
 sample_files/
 test_jobs.csv
-test_dist/
+test_dist*/
+build[0-9]*/
 
 # Claude Code and development notes
 .claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,7 @@ old/
 
 # Shared addon packages dir (managed at runtime via pip, not checked in)
 # Lives in %LOCALAPPDATA%\JobDocs\AddonPackages\ — dev symlink if present
-AddonPackages/
+/AddonPackages/
 
 # Flatpak — staged binary and icon (copied from build_dist/ by CI, not source files)
 linux/flatpak/JobDocs

--- a/build_scripts/JobDocs.iss
+++ b/build_scripts/JobDocs.iss
@@ -32,15 +32,23 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
 
 [Dirs]
+; plugins/ is never removed on uninstall so user-installed plugins survive upgrades
 Name: "{app}\plugins"; Flags: uninsneveruninstall
 
 [Files]
-Source: "..\dist\JobDocs\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+; Launcher executable
+Source: "..\JobDocs.exe";    DestDir: "{app}"; Flags: ignoreversion
+
+; Python source tree (runs via runtime\pythonw.exe)
+Source: "..\app\*";          DestDir: "{app}\app"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+; Embedded Python 3.12 runtime with pre-installed dependencies
+Source: "..\runtime\*";      DestDir: "{app}\runtime"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
-Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; IconFilename: "{app}\{#MyAppExeName}"
-Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
-Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; IconFilename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+Name: "{group}\{#MyAppName}";                          Filename: "{app}\{#MyAppExeName}"; IconFilename: "{app}\{#MyAppExeName}"
+Name: "{group}\{cm:UninstallProgram,{#MyAppName}}";    Filename: "{uninstallexe}"
+Name: "{autodesktop}\{#MyAppName}";                    Filename: "{app}\{#MyAppExeName}"; IconFilename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
 
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent

--- a/build_scripts/JobDocs.spec
+++ b/build_scripts/JobDocs.spec
@@ -187,6 +187,12 @@ a = Analysis(
         'PIL',
         'IPython',
         'jupyter',
+
+        # PyMuPDF's pymupdf.table optionally imports pandas for table detection;
+        # we only use fitz for page rendering so exclude it to keep plugin deps
+        # out of the main bundle (plugins install their own deps/ at runtime).
+        'pandas',
+        'openpyxl',
     ],
     win_no_prefer_redirects=False,
     win_private_assemblies=False,

--- a/build_scripts/JobDocs.spec
+++ b/build_scripts/JobDocs.spec
@@ -160,10 +160,10 @@ hiddenimports = [
 ]
 
 # Plugin dependencies are NOT bundled here.
-# Each plugin manages its own deps in a deps/ subfolder next to its module.py.
-# The module loader prepends that folder to sys.path before exec_module so the
-# plugin can import normally. The plugin installer (main.py) runs pip install
-# --target deps/ from the plugin's requirements.txt at install time.
+# When a plugin is installed, main.py shells out to:
+#   python -m pip install -r <plugin>/requirements.txt
+# which installs deps into the running Python environment (embedded runtime\
+# site-packages in a release build, the dev venv when running from source).
 
 # Find main.py
 main_py = spec_root / 'main.py'

--- a/build_scripts/JobDocs.spec
+++ b/build_scripts/JobDocs.spec
@@ -13,7 +13,6 @@ Usage:
 Generated executable will be in the dist/ directory (or custom path if specified).
 """
 
-from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 import os
 from pathlib import Path
 
@@ -155,19 +154,11 @@ hiddenimports = [
     'difflib',
 ]
 
-# Third-party packages required by plugins (e.g. jobdocs-report-fixer uses pandas + openpyxl).
-#
-# Architectural note: because this is a onedir build, pure-Python plugin dependencies
-# could in principle live in a plugin's own deps/ subfolder (added to sys.path by the
-# plugin loader before exec_module). However, pandas contains compiled .pyd extensions
-# that must exactly match the Python version bundled by PyInstaller — they cannot be
-# shipped portably alongside a plugin. pandas must therefore be declared here so
-# PyInstaller includes the correct pre-compiled binaries in the bundle.
-# openpyxl is included here for the same reason as pandas (consistency and to avoid
-# a split deps model until a proper per-plugin deps/ system is implemented).
-hiddenimports += collect_submodules('pandas')
-hiddenimports += collect_submodules('openpyxl')
-datas += collect_data_files('pandas')
+# Plugin dependencies are NOT bundled here.
+# Each plugin manages its own deps in a deps/ subfolder next to its module.py.
+# The module loader prepends that folder to sys.path before exec_module so the
+# plugin can import normally. The plugin installer (main.py) runs pip install
+# --target deps/ from the plugin's requirements.txt at install time.
 
 # Find main.py
 main_py = spec_root / 'main.py'

--- a/build_scripts/JobDocs.spec
+++ b/build_scripts/JobDocs.spec
@@ -152,6 +152,11 @@ hiddenimports = [
 
     # stdlib modules used by dynamically-loaded plugins (not reachable via static analysis)
     'difflib',
+
+    # pip internal API — used by the plugin installer to install plugin deps at
+    # runtime without requiring a separate Python installation on the user's machine.
+    'pip',
+    'pip._internal.cli.main',
 ]
 
 # Plugin dependencies are NOT bundled here.

--- a/core/module_loader.py
+++ b/core/module_loader.py
@@ -150,6 +150,14 @@ class ModuleLoader:
             if not module_path.exists():
                 raise ImportError(f"Plugin module file not found: {module_path}")
 
+            # Prepend the plugin's deps/ directory to sys.path so that packages
+            # installed there (via pip install --target) are importable.
+            deps_dir = module_path.parent / 'deps'
+            if deps_dir.exists():
+                deps_str = str(deps_dir)
+                if deps_str not in sys.path:
+                    sys.path.insert(0, deps_str)
+
             # Register a parent package entry so relative imports (e.g. `from .helpers`)
             # inside the plugin resolve correctly.
             package_name = f"plugins.{module_name}"

--- a/core/module_loader.py
+++ b/core/module_loader.py
@@ -150,14 +150,6 @@ class ModuleLoader:
             if not module_path.exists():
                 raise ImportError(f"Plugin module file not found: {module_path}")
 
-            # Prepend the plugin's deps/ directory to sys.path so that packages
-            # installed there (via pip install --target) are importable.
-            deps_dir = module_path.parent / 'deps'
-            if deps_dir.exists():
-                deps_str = str(deps_dir)
-                if deps_str not in sys.path:
-                    sys.path.insert(0, deps_str)
-
             # Register a parent package entry so relative imports (e.g. `from .helpers`)
             # inside the plugin resolve correctly.
             package_name = f"plugins.{module_name}"

--- a/launcher/launcher.c
+++ b/launcher/launcher.c
@@ -1,0 +1,67 @@
+/*
+ * JobDocs launcher
+ *
+ * Finds runtime\pythonw.exe relative to this executable and launches
+ * app\main.py with no visible console window. The working directory is
+ * set to the install root so relative paths inside the app resolve correctly.
+ *
+ * Build (MinGW, GitHub Actions windows-latest):
+ *   windres launcher/launcher.rc -O coff -o launcher_res.o
+ *   gcc -mwindows -O2 -o JobDocs.exe launcher/launcher.c launcher_res.o
+ */
+
+#ifndef UNICODE
+#define UNICODE
+#endif
+#ifndef _UNICODE
+#define _UNICODE
+#endif
+
+#include <windows.h>
+#include <wchar.h>
+
+int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR lpCmd, int nShow)
+{
+    /* Resolve the directory this exe lives in. */
+    wchar_t exe_path[MAX_PATH];
+    GetModuleFileNameW(NULL, exe_path, MAX_PATH);
+    wchar_t *last_sep = wcsrchr(exe_path, L'\\');
+    if (last_sep) *last_sep = L'\0';
+
+    /* Build paths to the embedded interpreter and the main script. */
+    wchar_t python[MAX_PATH];
+    wchar_t script[MAX_PATH];
+    _snwprintf_s(python, MAX_PATH, _TRUNCATE,
+                 L"%s\\runtime\\pythonw.exe", exe_path);
+    _snwprintf_s(script, MAX_PATH, _TRUNCATE,
+                 L"%s\\app\\main.py", exe_path);
+
+    /* CreateProcess wants a mutable command-line buffer. */
+    wchar_t cmdline[MAX_PATH * 2];
+    _snwprintf_s(cmdline, MAX_PATH * 2, _TRUNCATE,
+                 L"\"%s\" \"%s\"", python, script);
+
+    STARTUPINFOW si;
+    ZeroMemory(&si, sizeof(si));
+    si.cb = sizeof(si);
+
+    PROCESS_INFORMATION pi;
+    ZeroMemory(&pi, sizeof(pi));
+
+    CreateProcessW(
+        python,     /* application */
+        cmdline,    /* command line */
+        NULL,       /* process security */
+        NULL,       /* thread security */
+        FALSE,      /* don't inherit handles */
+        0,          /* creation flags */
+        NULL,       /* inherit environment */
+        exe_path,   /* working directory = install root */
+        &si,
+        &pi
+    );
+
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+    return 0;
+}

--- a/launcher/launcher.c
+++ b/launcher/launcher.c
@@ -48,7 +48,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR lpCmd, int nShow)
     PROCESS_INFORMATION pi;
     ZeroMemory(&pi, sizeof(pi));
 
-    CreateProcessW(
+    BOOL created = CreateProcessW(
         python,     /* application */
         cmdline,    /* command line */
         NULL,       /* process security */
@@ -60,6 +60,19 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR lpCmd, int nShow)
         &si,
         &pi
     );
+
+    if (!created) {
+        DWORD err = GetLastError();
+        wchar_t msg[512];
+        _snwprintf_s(msg, 512, _TRUNCATE,
+                     L"Failed to start JobDocs.\n\n"
+                     L"Python: %s\n"
+                     L"Script: %s\n"
+                     L"Error code: %lu",
+                     python, script, (unsigned long)err);
+        MessageBoxW(NULL, msg, L"JobDocs Launch Error", MB_OK | MB_ICONERROR);
+        return 1;
+    }
 
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);

--- a/launcher/launcher.rc
+++ b/launcher/launcher.rc
@@ -1,0 +1,37 @@
+// Resource file for JobDocs launcher
+// Embeds the application icon into JobDocs.exe
+
+#include <winver.h>
+
+// Application icon
+IDI_ICON1 ICON "..\windows\icon.ico"
+
+// Version information
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION     0,6,0,0
+PRODUCTVERSION  0,6,0,0
+FILEFLAGSMASK   VS_FFI_FILEFLAGSMASK
+FILEFLAGS       0
+FILEOS          VOS__WINDOWS32
+FILETYPE        VFT_APP
+FILESUBTYPE     VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName",      "i-machine-things"
+            VALUE "FileDescription",  "JobDocs - Job and Quote Management"
+            VALUE "FileVersion",      "0.6.0.0"
+            VALUE "InternalName",     "JobDocs"
+            VALUE "LegalCopyright",   "i-machine-things"
+            VALUE "OriginalFilename", "JobDocs.exe"
+            VALUE "ProductName",      "JobDocs"
+            VALUE "ProductVersion",   "0.6.0.0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0409, 0x04b0
+    END
+END

--- a/launcher/launcher.rc
+++ b/launcher/launcher.rc
@@ -1,15 +1,38 @@
 // Resource file for JobDocs launcher
 // Embeds the application icon into JobDocs.exe
+//
+// Version numbers are injected at build time via windres preprocessor defines:
+//   -D VERSION_MAJOR=<n> -D VERSION_MINOR=<n> -D VERSION_PATCH=<n> -D VERSION_BUILD=<n>
+// Fallback values below are used during local/dev builds only.
 
 #include <winver.h>
+
+#ifndef VERSION_MAJOR
+#define VERSION_MAJOR 0
+#endif
+#ifndef VERSION_MINOR
+#define VERSION_MINOR 6
+#endif
+#ifndef VERSION_PATCH
+#define VERSION_PATCH 0
+#endif
+#ifndef VERSION_BUILD
+#define VERSION_BUILD 0
+#endif
+
+// Stringify helpers for the human-readable version string
+#define _VER_STR(x) #x
+#define VER_STR(x)  _VER_STR(x)
+#define VER_STRING  VER_STR(VERSION_MAJOR) "." VER_STR(VERSION_MINOR) "." \
+                    VER_STR(VERSION_PATCH) "." VER_STR(VERSION_BUILD)
 
 // Application icon
 IDI_ICON1 ICON "..\windows\icon.ico"
 
 // Version information
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION     0,6,0,0
-PRODUCTVERSION  0,6,0,0
+FILEVERSION     VERSION_MAJOR,VERSION_MINOR,VERSION_PATCH,VERSION_BUILD
+PRODUCTVERSION  VERSION_MAJOR,VERSION_MINOR,VERSION_PATCH,VERSION_BUILD
 FILEFLAGSMASK   VS_FFI_FILEFLAGSMASK
 FILEFLAGS       0
 FILEOS          VOS__WINDOWS32
@@ -22,12 +45,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName",      "i-machine-things"
             VALUE "FileDescription",  "JobDocs - Job and Quote Management"
-            VALUE "FileVersion",      "0.6.0.0"
+            VALUE "FileVersion",      VER_STRING
             VALUE "InternalName",     "JobDocs"
             VALUE "LegalCopyright",   "i-machine-things"
             VALUE "OriginalFilename", "JobDocs.exe"
             VALUE "ProductName",      "JobDocs"
-            VALUE "ProductVersion",   "0.6.0.0"
+            VALUE "ProductVersion",   VER_STRING
         END
     END
     BLOCK "VarFileInfo"

--- a/main.py
+++ b/main.py
@@ -53,58 +53,91 @@ class _PluginInstallWorker(QThread):
             return ''
 
         deps_dir = plugin_dir / 'deps'
+
+        # Install into a temp dir then swap atomically to avoid leaving deps_dir
+        # in a partial state if the install fails mid-way.
+        tmp_deps = deps_dir.with_name('deps.tmp')
         try:
-            deps_dir.mkdir(parents=True, exist_ok=True)
+            if tmp_deps.exists():
+                shutil.rmtree(tmp_deps)
+            tmp_deps.mkdir(parents=True, exist_ok=True)
         except OSError as e:
-            return f"\n\nCould not create deps directory: {e}"
+            return f"\n\nCould not create temp deps directory: {e}"
 
-        # In dev mode sys.executable is Python, so try it first.
-        # In a frozen build it is the exe itself; fall back to system Python,
-        # then to pip's own internal API (bundled with Python/the frozen exe).
-        candidates = []
-        if not getattr(sys, 'frozen', False):
-            candidates.append(sys.executable)
-        candidates.extend(['python', 'python3', 'py'])
-
+        # Fix CR: in frozen mode try the bundled pip API first so wheels are
+        # resolved against the bundled Python ABI, not a system Python that may
+        # differ. Fall back to system Python names only after that attempt fails.
         last_err = ''
-        for python in candidates:
+        installed = False
+
+        if getattr(sys, 'frozen', False):
             try:
-                result = subprocess.run(
-                    [python, '-m', 'pip', 'install',
-                     '--target', str(deps_dir),
-                     '-r', str(req_file)],
-                    capture_output=True, text=True, timeout=120,
-                )
-                if result.returncode == 0:
-                    return ''
-                last_err = (result.stderr or result.stdout).strip()
-            except FileNotFoundError:
-                continue
-            except subprocess.TimeoutExpired:
-                last_err = 'pip install timed out after 120 s'
-                break
+                from pip._internal.cli.main import main as _pip_main  # type: ignore[import]
+                args = ['install', '--target', str(tmp_deps), '-r', str(req_file)]
+                rc = _pip_main(args)
+                installed = (rc == 0)
+                if not installed:
+                    last_err = f'pip internal API exited with code {rc}'
+            except SystemExit as exc:
+                installed = (exc.code or 0) == 0
+                if not installed:
+                    last_err = f'pip internal API exited with code {exc.code}'
+            except Exception as exc:
+                last_err = str(exc)
 
-        # Last resort: call pip's internal API directly (works in frozen builds
-        # where no system Python is on PATH, since pip ships with Python).
+        if not installed:
+            candidates = []
+            if not getattr(sys, 'frozen', False):
+                candidates.append(sys.executable)
+            candidates.extend(['python', 'python3', 'py'])
+
+            for python in candidates:
+                try:
+                    result = subprocess.run(
+                        [python, '-m', 'pip', 'install',
+                         '--target', str(tmp_deps),
+                         '-r', str(req_file)],
+                        capture_output=True, text=True, timeout=120,
+                    )
+                    if result.returncode == 0:
+                        installed = True
+                        break
+                    last_err = (result.stderr or result.stdout).strip()
+                except FileNotFoundError:
+                    continue
+                except subprocess.TimeoutExpired:
+                    last_err = 'pip install timed out after 120 s'
+                    break
+
+        if not installed:
+            shutil.rmtree(tmp_deps, ignore_errors=True)
+            return (
+                f"\n\nPlugin installed, but dependencies could not be installed automatically.\n"
+                f"Run manually: pip install --target \"{deps_dir}\" -r \"{req_file}\"\n\n"
+                f"Error: {last_err or 'no usable Python found on PATH'}"
+            )
+
+        # Atomically swap temp dir into place (backup-then-swap).
+        backup = deps_dir.with_name('deps.bak')
         try:
-            from pip._internal.cli.main import main as _pip_main  # type: ignore[import]
-            args = ['install', '--target', str(deps_dir), '-r', str(req_file)]
-            rc = _pip_main(args)
-            if rc == 0:
-                return ''
-            last_err = f'pip internal API exited with code {rc}'
-        except SystemExit as exc:
-            if (exc.code or 0) == 0:
-                return ''
-            last_err = f'pip internal API exited with code {exc.code}'
-        except Exception as exc:
-            last_err = str(exc)
+            if backup.exists():
+                shutil.rmtree(backup)
+            if deps_dir.exists():
+                deps_dir.rename(backup)
+            tmp_deps.rename(deps_dir)
+            if backup.exists():
+                shutil.rmtree(backup)
+        except Exception:
+            if tmp_deps.exists() and not deps_dir.exists():
+                try:
+                    tmp_deps.rename(deps_dir)
+                except Exception:
+                    pass
+            if backup.exists() and not deps_dir.exists():
+                backup.rename(deps_dir)
+            raise
 
-        return (
-            f"\n\nPlugin installed, but dependencies could not be installed automatically.\n"
-            f"Run manually: pip install -r \"{req_file}\"\n\n"
-            f"Error: {last_err or 'no usable Python found on PATH'}"
-        )
+        return ''
 
     def run(self):
         owner, repo = self._owner, self._repo

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ Main application entry point using the modular plugin architecture.
 """
 
 import io
+import os
 import shutil
 import subprocess
 import sys
@@ -52,6 +53,14 @@ class _PluginInstallWorker(QThread):
         req_file = plugin_dir / 'requirements.txt'
         if not req_file.exists():
             return ''
+
+        # On Flatpak, /app is read-only at runtime; pip installs will always fail.
+        if os.getenv('FLATPAK_ID'):
+            return (
+                f"\n\nDependency installation skipped: running inside Flatpak "
+                f"(read-only filesystem).\n"
+                f"Install manually: pip install -r \"{req_file}\""
+            )
 
         try:
             result = subprocess.run(

--- a/main.py
+++ b/main.py
@@ -59,7 +59,7 @@ class _PluginInstallWorker(QThread):
             return (
                 f"\n\nDependency installation skipped: running inside Flatpak "
                 f"(read-only filesystem).\n"
-                f"Install manually: pip install -r \"{req_file}\""
+                f"Install manually: {sys.executable} -m pip install -r \"{req_file}\""
             )
 
         try:
@@ -73,7 +73,7 @@ class _PluginInstallWorker(QThread):
                 return ''
             err = (result.stderr or result.stdout).strip()
             return (f"\n\nDependency installation failed.\n"
-                    f"Run manually: pip install -r \"{req_file}\"\n\nError: {err}")
+                    f"Run manually: {sys.executable} -m pip install -r \"{req_file}\"\n\nError: {err}")
         except Exception as exc:
             return f"\n\nDependency installation failed: {exc}"
 
@@ -578,10 +578,12 @@ class JobDocsMainWindow(QMainWindow):
         worker.start()
 
     def _on_plugin_install_success(self, module_name: str, dest: str, dep_warning: str, worker: _PluginInstallWorker):
-        msg = f"Plugin '{module_name}' installed to:\n{dest}\n\nRestart JobDocs to load it."
         if dep_warning:
+            msg = (f"Plugin '{module_name}' files copied to:\n{dest}\n\n"
+                   f"The plugin may not load until dependencies are resolved.")
             QMessageBox.warning(self, "Plugin Installed", msg + dep_warning)
         else:
+            msg = f"Plugin '{module_name}' installed to:\n{dest}\n\nRestart JobDocs to load it."
             QMessageBox.information(self, "Plugin Installed", msg)
         worker.deleteLater()
 

--- a/main.py
+++ b/main.py
@@ -52,11 +52,13 @@ class _PluginInstallWorker(QThread):
         if not req_file.exists():
             return ''
 
-        deps_dir = plugin_dir / 'deps'
+        # Shared addon packages dir — all plugins install here so packages
+        # like pandas are not duplicated when multiple plugins need them.
+        deps_dir = get_config_dir() / 'AddonPackages'
 
         # Install into a temp dir then swap atomically to avoid leaving deps_dir
         # in a partial state if the install fails mid-way.
-        tmp_deps = deps_dir.with_name('deps.tmp')
+        tmp_deps = deps_dir.with_name('AddonPackages.tmp')
         try:
             if tmp_deps.exists():
                 shutil.rmtree(tmp_deps)
@@ -836,6 +838,14 @@ Search across all customers and jobs.</p>
 
 def main():
     """Main application entry point"""
+    # Prepend the shared addon packages directory to sys.path so plugin
+    # dependencies installed there are importable before any modules load.
+    addon_packages = get_config_dir() / 'AddonPackages'
+    if addon_packages.exists():
+        addon_str = str(addon_packages)
+        if addon_str not in sys.path:
+            sys.path.insert(0, addon_str)
+
     # Set AppUserModelID so Windows can pin this to the taskbar
     try:
         import ctypes

--- a/main.py
+++ b/main.py
@@ -58,8 +58,9 @@ class _PluginInstallWorker(QThread):
         except OSError as e:
             return f"\n\nCould not create deps directory: {e}"
 
-        # Try to find a usable Python. In dev mode sys.executable is Python.
-        # In a frozen build it is the exe itself, so fall back to system Python.
+        # In dev mode sys.executable is Python, so try it first.
+        # In a frozen build it is the exe itself; fall back to system Python,
+        # then to pip's own internal API (bundled with Python/the frozen exe).
         candidates = []
         if not getattr(sys, 'frozen', False):
             candidates.append(sys.executable)
@@ -82,6 +83,22 @@ class _PluginInstallWorker(QThread):
             except subprocess.TimeoutExpired:
                 last_err = 'pip install timed out after 120 s'
                 break
+
+        # Last resort: call pip's internal API directly (works in frozen builds
+        # where no system Python is on PATH, since pip ships with Python).
+        try:
+            from pip._internal.cli.main import main as _pip_main  # type: ignore[import]
+            args = ['install', '--target', str(deps_dir), '-r', str(req_file)]
+            rc = _pip_main(args)
+            if rc == 0:
+                return ''
+            last_err = f'pip internal API exited with code {rc}'
+        except SystemExit as exc:
+            if (exc.code or 0) == 0:
+                return ''
+            last_err = f'pip internal API exited with code {exc.code}'
+        except Exception as exc:
+            last_err = str(exc)
 
         return (
             f"\n\nPlugin installed, but dependencies could not be installed automatically.\n"

--- a/main.py
+++ b/main.py
@@ -100,6 +100,7 @@ class _PluginInstallWorker(QThread):
                          '--target', str(tmp_deps),
                          '-r', str(req_file)],
                         capture_output=True, text=True, timeout=120,
+                        creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == 'win32' else 0,
                     )
                     if result.returncode == 0:
                         installed = True

--- a/main.py
+++ b/main.py
@@ -58,8 +58,8 @@ class _PluginInstallWorker(QThread):
         # Manual install via sys.executable is also unsupported (same read-only runtime).
         if os.getenv('FLATPAK_ID'):
             return (
-                f"\n\nDependency installation is not supported inside a Flatpak build.\n"
-                f"Install the plugin's dependencies on the host system before use."
+                "\n\nDependency installation is not supported inside a Flatpak build.\n"
+                "Install the plugin's dependencies on the host system before use."
             )
 
         try:

--- a/main.py
+++ b/main.py
@@ -407,7 +407,16 @@ class JobDocsMainWindow(QMainWindow):
         Dev / source layout:
             repo/main.py
             repo/plugins/       ← plugins live here
+
+        Flatpak: /app is read-only at runtime; plugins must live in the
+        per-user writable data dir so they survive across app updates.
         """
+        flatpak_id = os.getenv('FLATPAK_ID')
+        if flatpak_id:
+            xdg_data = os.getenv('XDG_DATA_HOME') or os.path.join(
+                os.path.expanduser('~'), '.var', 'app', flatpak_id, 'data'
+            )
+            return Path(xdg_data) / 'plugins'
         app_dir = Path(__file__).resolve().parent
         if (app_dir.parent / 'runtime').is_dir():
             return app_dir.parent / 'plugins'

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ Main application entry point using the modular plugin architecture.
 
 import io
 import shutil
+import subprocess
 import sys
 import json
 import tempfile
@@ -32,7 +33,7 @@ from shared.remote_sync import RemoteSyncManager
 class _PluginInstallWorker(QThread):
     """Background worker that downloads and extracts a GitHub plugin."""
 
-    success = pyqtSignal(str, str)  # module_name, dest_path
+    success = pyqtSignal(str, str, str)  # module_name, dest_path, dep_warning
     error = pyqtSignal(str)
 
     def __init__(self, owner: str, repo: str, plugins_dir: Path):
@@ -40,6 +41,53 @@ class _PluginInstallWorker(QThread):
         self._owner = owner
         self._repo = repo
         self._plugins_dir = plugins_dir
+
+    def _install_deps(self, plugin_dir: Path) -> str:
+        """Install requirements.txt into plugin_dir/deps/ using pip.
+
+        Returns a non-empty warning string if installation failed or was skipped,
+        or '' on success / no requirements.txt present.
+        """
+        req_file = plugin_dir / 'requirements.txt'
+        if not req_file.exists():
+            return ''
+
+        deps_dir = plugin_dir / 'deps'
+        try:
+            deps_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            return f"\n\nCould not create deps directory: {e}"
+
+        # Try to find a usable Python. In dev mode sys.executable is Python.
+        # In a frozen build it is the exe itself, so fall back to system Python.
+        candidates = []
+        if not getattr(sys, 'frozen', False):
+            candidates.append(sys.executable)
+        candidates.extend(['python', 'python3', 'py'])
+
+        last_err = ''
+        for python in candidates:
+            try:
+                result = subprocess.run(
+                    [python, '-m', 'pip', 'install',
+                     '--target', str(deps_dir),
+                     '-r', str(req_file)],
+                    capture_output=True, text=True, timeout=120,
+                )
+                if result.returncode == 0:
+                    return ''
+                last_err = (result.stderr or result.stdout).strip()
+            except FileNotFoundError:
+                continue
+            except subprocess.TimeoutExpired:
+                last_err = 'pip install timed out after 120 s'
+                break
+
+        return (
+            f"\n\nPlugin installed, but dependencies could not be installed automatically.\n"
+            f"Run manually: pip install -r \"{req_file}\"\n\n"
+            f"Error: {last_err or 'no usable Python found on PATH'}"
+        )
 
     def run(self):
         owner, repo = self._owner, self._repo
@@ -129,7 +177,8 @@ class _PluginInstallWorker(QThread):
                                 backup_dest.rename(dest)
                             raise
 
-                self.success.emit(module_name, str(dest))
+                dep_warning = self._install_deps(dest)
+                self.success.emit(module_name, str(dest), dep_warning)
                 return
 
             except urllib.error.HTTPError as e:
@@ -509,16 +558,17 @@ class JobDocsMainWindow(QMainWindow):
         plugins_dir = self._get_plugins_dir()
 
         worker = _PluginInstallWorker(owner, repo, plugins_dir)
-        worker.success.connect(lambda name, dest: self._on_plugin_install_success(name, dest, worker))
+        worker.success.connect(lambda name, dest, warn: self._on_plugin_install_success(name, dest, warn, worker))
         worker.error.connect(lambda msg: self._on_plugin_install_error(msg, worker))
         self._install_worker = worker  # prevent GC while running
         worker.start()
 
-    def _on_plugin_install_success(self, module_name: str, dest: str, worker: _PluginInstallWorker):
-        QMessageBox.information(
-            self, "Plugin Installed",
-            f"Plugin '{module_name}' installed to:\n{dest}\n\nRestart JobDocs to load it."
-        )
+    def _on_plugin_install_success(self, module_name: str, dest: str, dep_warning: str, worker: _PluginInstallWorker):
+        msg = f"Plugin '{module_name}' installed to:\n{dest}\n\nRestart JobDocs to load it."
+        if dep_warning:
+            QMessageBox.warning(self, "Plugin Installed", msg + dep_warning)
+        else:
+            QMessageBox.information(self, "Plugin Installed", msg)
         worker.deleteLater()
 
     def _on_plugin_install_error(self, message: str, worker: _PluginInstallWorker):

--- a/main.py
+++ b/main.py
@@ -43,104 +43,30 @@ class _PluginInstallWorker(QThread):
         self._plugins_dir = plugins_dir
 
     def _install_deps(self, plugin_dir: Path) -> str:
-        """Install requirements.txt into plugin_dir/deps/ using pip.
+        """Install plugin requirements into the embedded Python's site-packages.
 
-        Returns a non-empty warning string if installation failed or was skipped,
-        or '' on success / no requirements.txt present.
+        Uses sys.executable (the embedded runtime\python.exe in a release build,
+        or the dev Python when running from source). Returns a non-empty warning
+        string on failure, or '' on success / no requirements.txt present.
         """
         req_file = plugin_dir / 'requirements.txt'
         if not req_file.exists():
             return ''
 
-        # Shared addon packages dir — all plugins install here so packages
-        # like pandas are not duplicated when multiple plugins need them.
-        deps_dir = get_config_dir() / 'AddonPackages'
-
-        # Install into a temp dir then swap atomically to avoid leaving deps_dir
-        # in a partial state if the install fails mid-way.
-        tmp_deps = deps_dir.with_name('AddonPackages.tmp')
         try:
-            if tmp_deps.exists():
-                shutil.rmtree(tmp_deps)
-            tmp_deps.mkdir(parents=True, exist_ok=True)
-        except OSError as e:
-            return f"\n\nCould not create temp deps directory: {e}"
-
-        # Fix CR: in frozen mode try the bundled pip API first so wheels are
-        # resolved against the bundled Python ABI, not a system Python that may
-        # differ. Fall back to system Python names only after that attempt fails.
-        last_err = ''
-        installed = False
-
-        if getattr(sys, 'frozen', False):
-            try:
-                from pip._internal.cli.main import main as _pip_main  # type: ignore[import]
-                args = ['install', '--target', str(tmp_deps), '-r', str(req_file)]
-                rc = _pip_main(args)
-                installed = (rc == 0)
-                if not installed:
-                    last_err = f'pip internal API exited with code {rc}'
-            except SystemExit as exc:
-                installed = (exc.code or 0) == 0
-                if not installed:
-                    last_err = f'pip internal API exited with code {exc.code}'
-            except Exception as exc:
-                last_err = str(exc)
-
-        if not installed:
-            candidates = []
-            if not getattr(sys, 'frozen', False):
-                candidates.append(sys.executable)
-            candidates.extend(['python', 'python3', 'py'])
-
-            for python in candidates:
-                try:
-                    result = subprocess.run(
-                        [python, '-m', 'pip', 'install',
-                         '--target', str(tmp_deps),
-                         '-r', str(req_file)],
-                        capture_output=True, text=True, timeout=120,
-                        creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == 'win32' else 0,
-                    )
-                    if result.returncode == 0:
-                        installed = True
-                        break
-                    last_err = (result.stderr or result.stdout).strip()
-                except FileNotFoundError:
-                    continue
-                except subprocess.TimeoutExpired:
-                    last_err = 'pip install timed out after 120 s'
-                    break
-
-        if not installed:
-            shutil.rmtree(tmp_deps, ignore_errors=True)
-            return (
-                f"\n\nPlugin installed, but dependencies could not be installed automatically.\n"
-                f"Run manually: pip install --target \"{deps_dir}\" -r \"{req_file}\"\n\n"
-                f"Error: {last_err or 'no usable Python found on PATH'}"
+            result = subprocess.run(
+                [sys.executable, '-m', 'pip', 'install',
+                 '--no-warn-script-location', '-r', str(req_file)],
+                capture_output=True, text=True, timeout=300,
+                creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == 'win32' else 0,
             )
-
-        # Atomically swap temp dir into place (backup-then-swap).
-        backup = deps_dir.with_name('deps.bak')
-        try:
-            if backup.exists():
-                shutil.rmtree(backup)
-            if deps_dir.exists():
-                deps_dir.rename(backup)
-            tmp_deps.rename(deps_dir)
-            if backup.exists():
-                shutil.rmtree(backup)
-        except Exception:
-            if tmp_deps.exists() and not deps_dir.exists():
-                try:
-                    tmp_deps.rename(deps_dir)
-                except Exception:
-                    pass
-            if backup.exists() and not deps_dir.exists():
-                backup.rename(deps_dir)
-            raise
-
-        return ''
+            if result.returncode == 0:
+                return ''
+            err = (result.stderr or result.stdout).strip()
+            return (f"\n\nDependency installation failed.\n"
+                    f"Run manually: pip install -r \"{req_file}\"\n\nError: {err}")
+        except Exception as exc:
+            return f"\n\nDependency installation failed: {exc}"
 
     def run(self):
         owner, repo = self._owner, self._repo
@@ -443,7 +369,13 @@ class JobDocsMainWindow(QMainWindow):
 
     def _set_window_icon(self):
         """Set application window icon from bundled or filesystem icon."""
-        base = Path(sys._MEIPASS) if getattr(sys, 'frozen', False) else Path(__file__).parent
+        # PyInstaller frozen: data files land in sys._MEIPASS.
+        # Embedded Python: icon is staged into app/ alongside main.py.
+        # Dev: same directory as main.py.
+        if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+            base = Path(sys._MEIPASS)
+        else:
+            base = Path(__file__).resolve().parent
         candidates = [
             base / 'windows' / 'icon.ico',
             base / 'JobDocs.iconset' / 'icon_256x256.png',
@@ -456,10 +388,21 @@ class JobDocsMainWindow(QMainWindow):
     # ==================== Module Loading ====================
 
     def _get_plugins_dir(self) -> Path:
-        """Return the fixed plugins directory alongside the executable (or repo root in dev)."""
-        if getattr(sys, 'frozen', False):
-            return Path(sys.executable).parent / 'plugins'
-        return Path(__file__).parent / 'plugins'
+        """Return the plugins directory.
+
+        Embedded install layout:
+            {app}/app/main.py   ← __file__
+            {app}/runtime/      ← signals we're in an embedded install
+            {app}/plugins/      ← plugins live here
+
+        Dev / source layout:
+            repo/main.py
+            repo/plugins/       ← plugins live here
+        """
+        app_dir = Path(__file__).resolve().parent
+        if (app_dir.parent / 'runtime').is_dir():
+            return app_dir.parent / 'plugins'
+        return app_dir / 'plugins'
 
     def load_modules(self):
         """Load all modules using the module loader"""
@@ -839,14 +782,6 @@ Search across all customers and jobs.</p>
 
 def main():
     """Main application entry point"""
-    # Prepend the shared addon packages directory to sys.path so plugin
-    # dependencies installed there are importable before any modules load.
-    addon_packages = get_config_dir() / 'AddonPackages'
-    if addon_packages.exists():
-        addon_str = str(addon_packages)
-        if addon_str not in sys.path:
-            sys.path.insert(0, addon_str)
-
     # Set AppUserModelID so Windows can pin this to the taskbar
     try:
         import ctypes

--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ class _PluginInstallWorker(QThread):
     def _install_deps(self, plugin_dir: Path) -> str:
         """Install plugin requirements into the embedded Python's site-packages.
 
-        Uses sys.executable (the embedded runtime\python.exe in a release build,
+        Uses sys.executable (the embedded runtime\\python.exe in a release build,
         or the dev Python when running from source). Returns a non-empty warning
         string on failure, or '' on success / no requirements.txt present.
         """
@@ -55,11 +55,11 @@ class _PluginInstallWorker(QThread):
             return ''
 
         # On Flatpak, /app is read-only at runtime; pip installs will always fail.
+        # Manual install via sys.executable is also unsupported (same read-only runtime).
         if os.getenv('FLATPAK_ID'):
             return (
-                f"\n\nDependency installation skipped: running inside Flatpak "
-                f"(read-only filesystem).\n"
-                f"Install manually: {sys.executable} -m pip install -r \"{req_file}\""
+                f"\n\nDependency installation is not supported inside a Flatpak build.\n"
+                f"Install the plugin's dependencies on the host system before use."
             )
 
         try:
@@ -73,7 +73,7 @@ class _PluginInstallWorker(QThread):
                 return ''
             err = (result.stderr or result.stdout).strip()
             return (f"\n\nDependency installation failed.\n"
-                    f"Run manually: {sys.executable} -m pip install -r \"{req_file}\"\n\nError: {err}")
+                    f"Run manually: \"{sys.executable}\" -m pip install -r \"{req_file}\"\n\nError: {err}")
         except Exception as exc:
             return f"\n\nDependency installation failed: {exc}"
 


### PR DESCRIPTION
## Summary

- **Problem**: PyInstaller's `sys.executable` is the app `.exe`, not Python — so `pip install` from within the app can't install plugin deps into a usable location without admin rights or ugly hacks.
- **Solution**: Drop PyInstaller for Windows. Ship an embedded Python 3.12 runtime (`python-3.12.9-embed-amd64.zip`) alongside the app source tree. A tiny C launcher (`launcher.c`) starts `runtime\pythonw.exe app\main.py` silently.
- Plugin dep install now works trivially: `sys.executable` is the real embedded `pythonw.exe`, so `subprocess.run([sys.executable, '-m', 'pip', 'install', ...])` installs into site-packages with no admin rights required.

### Changes
- `launcher/launcher.c` + `launcher/launcher.rc`: MinGW-compiled WinMain launcher with embedded icon
- `.github/workflows/build-release.yml`: new build-windows job — download embed zip, enable site-packages, bootstrap pip, install deps, stage `app/`, compile launcher, run Inno Setup
- `build_scripts/JobDocs.iss`: packages `JobDocs.exe` + `app\` + `runtime\`; `plugins\` preserved on uninstall
- `main.py`: `_get_plugins_dir()` detects embedded layout; `_install_deps()` simplified to 15 lines; removed AddonPackages sys.path injection

## Test plan

- [ ] Push a `v*` tag from `stable` after merge and verify the Windows CI job completes — check that `JobDocs-*-windows-setup.exe` appears in the release
- [ ] Install the resulting `.exe`, launch JobDocs, confirm no console window appears
- [ ] Install the Report Fixer plugin via File → Install Plugin; confirm pandas/openpyxl install silently and the plugin loads on restart
- [ ] Verify `plugins\` directory survives an upgrade (uninstall + reinstall)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic plugin dependency installation during plugin add.
  * New native Windows launcher and embedded-Python packaging for installers.

* **Bug Fixes**
  * Improved plugin directory detection for embedded, Flatpak, and dev installs.
  * Better application icon/version resource handling.
  * Installer preserves plugins across upgrades/uninstalls.
  * UI now surfaces dependency-install warnings after plugin install.

* **Chores**
  * Updated build/release workflow and .gitignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->