### PR TITLE
ci: opt into Node.js 24 for all actions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - 'v*'
 
+# Opt into Node.js 24 for all actions until upstream releases Node.js 24-native
+# versions of checkout/setup-python/upload-artifact/download-artifact/cache.
+# Remove this once all actions are updated (deadline: 2026-06-02).
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   verify-stable-ancestry:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` at workflow level to suppress Node.js 20 deprecation warnings across all jobs
- Affects: `actions/checkout@v4`, `actions/setup-python@v5`, `actions/upload-artifact@v4`, `actions/download-artifact@v4`, `actions/cache@v4`

## Why
GitHub Actions will force Node.js 24 on 2026-06-02 and remove Node.js 20 on 2026-09-16. The env var is the recommended opt-in until upstream action maintainers release Node.js 24-native major versions.

## Follow-up
Remove the env var once all actions are updated to Node.js 24-native versions.

## Test plan
- [ ] Verify no Node.js 20 warnings on next tagged release build

🤖 Generated with [Claude Code](https://claude.com/claude-code)