### PR TITLE
feat: batch print drawings from job/quote/search

### DIFF
--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -5344,3 +5344,18 @@ Reviewing files that changed from the base of the PR and between 31d95fdc9858f9d
 </details>
 
 <!-- This is an auto-generated comment by CodeRabbit for review status -->
+
+## 2026-04-16 — `shared/utils.py`, `shared/widgets.py` (PR #24 — batch print)
+
+**Review:** CodeRabbit flagged redundant local `import subprocess` inside `open_folder()` and S603/S607 subprocess security warnings for bare `['lp', path]` call without verifying `lp` availability.
+**Result:** Removed redundant local import; guarded `lp` calls with `shutil.which('lp')` in both `utils.py` and `widgets.py`.
+
+### Findings
+
+1. **Redundant local import**
+   - `import subprocess` inside `open_folder()` duplicated the module-level import added when `print_files` was introduced
+   - Removed the local import
+
+2. **S607 — subprocess called without full path verification**
+   - `subprocess.Popen(['lp', path])` could fail silently on systems without `lp`
+   - Fixed: `lp = shutil.which('lp'); if lp: Popen([lp, path])`

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -5359,3 +5359,319 @@ Reviewing files that changed from the base of the PR and between 31d95fdc9858f9d
 2. **S607 — subprocess called without full path verification**
    - `subprocess.Popen(['lp', path])` could fail silently on systems without `lp`
    - Fixed: `lp = shutil.which('lp'); if lp: Popen([lp, path])`
+
+---
+
+## 2026-04-16 — `PR #24: feat: batch print drawings from job/quote/search` — review run 2
+
+**Actionable comments posted: 2**
+
+<details>
+<summary>🧹 Nitpick comments (4)</summary><blockquote>
+
+<details>
+<summary>shared/widgets.py (3)</summary><blockquote>
+
+`1380-1393`: **Type hints reference undefined names at module scope.**
+
+The string-based type hints (`'QPainter'`, `'QImage'`, `'QRectF'`) won't cause runtime errors, but static type checkers (mypy, pyright) won't resolve them. Consider using a `TYPE_CHECKING` import block:
+
+<details>
+<summary>🔧 Proposed fix</summary>
+
+Add near the top of the file with other imports:
+```python
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from PyQt6.QtGui import QPainter, QImage
+    from PyQt6.QtCore import QRectF
+```
+
+Then the function signature can use the actual types without strings:
+```diff
+-def _draw_image_fitted(painter: 'QPainter', img: 'QImage', page_rect: 'QRectF') -> None:  # type: ignore[name-defined]
++def _draw_image_fitted(painter: QPainter, img: QImage, page_rect: QRectF) -> None:
+```
+</details>
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In `@shared/widgets.py` around lines 1380 - 1393, The function _draw_image_fitted
+uses string-based type hints ('QPainter', 'QImage', 'QRectF') which static type
+checkers won't resolve; update the module to import actual types only for type
+checking by adding "from typing import TYPE_CHECKING" and inside an "if
+TYPE_CHECKING:" block import QPainter and QImage from PyQt6.QtGui and QRectF
+from PyQt6.QtCore, then change the _draw_image_fitted signature to use the real
+types (QPainter, QImage, QRectF) instead of strings so mypy/pyright can resolve
+them while avoiding runtime imports.
+```
+
+</details>
+
+---
+
+`1464-1471`: **Fallback print silently fails on non-Windows if `lp` is unavailable.**
+
+When `lp` is not found via `shutil.which`, non-renderable files are silently skipped with no user feedback. Consider logging a warning or collecting failed paths to report to the user:
+
+<details>
+<summary>🛡️ Proposed improvement</summary>
+
+```diff
+     for path in fallback:
+         if platform.system() == 'Windows':
+             os.startfile(path, 'print')  # type: ignore[attr-defined]
+         else:
+             import subprocess as _sp
+             lp = shutil.which('lp')
+             if lp:
+                 _sp.Popen([lp, path])
++            else:
++                # Consider logging or collecting these for user notification
++                print(f"[print_files_with_dialog] lp not found, cannot print: {path}", flush=True)
+```
+</details>
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In `@shared/widgets.py` around lines 1464 - 1471, The fallback printing loop
+silently skips non-Windows paths when 'lp' is absent; update the loop that
+iterates over fallback (the branch using platform.system(), os.startfile,
+shutil.which('lp') and _sp.Popen) to record any paths that cannot be printed
+(e.g., collect into a failed_paths list) and emit a warning after the loop
+(using the module logger or logging.warning) that includes those failed paths so
+users get feedback when 'lp' is unavailable; ensure the Windows branch
+(os.startfile) remains unchanged and only non-Windows missing-'lp' cases are
+reported.
+```
+
+</details>
+
+---
+
+`1428-1462`: **Consider wrapping QPainter in try/finally to ensure `end()` is called.**
+
+If an unexpected exception occurs during rendering (e.g., QImage creation fails), `painter.end()` won't be called, which can leave the printer in an inconsistent state.
+
+<details>
+<summary>🛡️ Proposed fix</summary>
+
+```diff
+         painter = QPainter(printer)
+-        page_rect = QRectF(painter.viewport())
+-        first = True
+-
+-        for path in renderable:
+-            # ... rendering logic ...
+-
+-        painter.end()
++        try:
++            page_rect = QRectF(painter.viewport())
++            first = True
++
++            for path in renderable:
++                # ... rendering logic ...
++        finally:
++            painter.end()
+```
+</details>
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In `@shared/widgets.py` around lines 1428 - 1462, The QPainter 'painter' created
+for 'printer' must be closed in a finally block so painter.end() always runs;
+wrap the main rendering loop (the code iterating over 'renderable' that calls
+QPainter(printer), QImage(...), _draw_image_fitted and fitz.open) in try/finally
+and call painter.end() from the finally clause, and also ensure any opened
+fitz.Document (doc) is closed on error (either by using a with/context manager
+or closing doc in a nested finally) so neither the printer nor PDF handles are
+left open.
+```
+
+</details>
+
+</blockquote></details>
+<details>
+<summary>core/app_context.py (1)</summary><blockquote>
+
+`87-98`: **Consider adding type hints for the print provider API.**
+
+The provider parameter and return type are untyped. For better IDE support and documentation, consider adding type hints. If you want to keep it flexible for plugins, `Any` or a `Protocol` would work:
+
+```python
+from typing import Protocol
+
+class PrintProvider(Protocol):
+    def add_files_to_list(self, paths: list) -> None: ...
+```
+
+Then: `def register_print_provider(self, provider: PrintProvider | None) -> None`
+
+This is optional but improves discoverability of the expected interface.
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In `@core/app_context.py` around lines 87 - 98, Add explicit typing for the print
+provider interface: define a PrintProvider Protocol (or use typing.Any) that
+declares add_files_to_list(self, paths: list) -> None, import it from typing,
+then update register_print_provider signature to accept provider: PrintProvider
+| None -> None and update get_print_provider to return Optional[PrintProvider]
+(or PrintProvider | None); update any internal references expecting
+_print_provider to reflect the new type.
+```
+
+</details>
+
+</blockquote></details>
+
+</blockquote></details>
+
+<details>
+<summary>🤖 Prompt for all review comments with AI agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+Inline comments:
+In `@shared/utils.py`:
+- Around line 205-216: Remove the unused print_files function from
+shared/utils.py: delete the entire def print_files(paths: List[str]) block and
+any related unused imports (os, platform, shutil, subprocess) if they become
+unused elsewhere; callers already use print_files_with_dialog in
+shared/widgets.py so no call sites need updating. If you prefer to keep it
+instead, add explicit error feedback/logging when the OS print handler fails
+(e.g., log when shutil.which('lp') returns None or when subprocess fails) so
+callers are not silently ignored. Ensure tests/imports still pass after removal.
+
+In `@shared/widgets.py`:
+- Around line 1435-1452: The fitz document opened with fitz.open(path) in the
+rendering block can leak if an exception happens before doc.close(); modify the
+rendering code around fitz.open(path) and doc.close() (the doc variable and the
+loop over doc.page_count) to ensure the document is always closed — either use a
+context manager (with fitz.open(path) as doc: ...) or wrap the existing logic in
+try/finally and call doc.close() in finally; keep the same rendering logic
+inside the managed block and preserve the ImportError fallback behavior.
+
+---
+
+Nitpick comments:
+In `@core/app_context.py`:
+- Around line 87-98: Add explicit typing for the print provider interface:
+define a PrintProvider Protocol (or use typing.Any) that declares
+add_files_to_list(self, paths: list) -> None, import it from typing, then update
+register_print_provider signature to accept provider: PrintProvider | None ->
+None and update get_print_provider to return Optional[PrintProvider] (or
+PrintProvider | None); update any internal references expecting _print_provider
+to reflect the new type.
+
+In `@shared/widgets.py`:
+- Around line 1380-1393: The function _draw_image_fitted uses string-based type
+hints ('QPainter', 'QImage', 'QRectF') which static type checkers won't resolve;
+update the module to import actual types only for type checking by adding "from
+typing import TYPE_CHECKING" and inside an "if TYPE_CHECKING:" block import
+QPainter and QImage from PyQt6.QtGui and QRectF from PyQt6.QtCore, then change
+the _draw_image_fitted signature to use the real types (QPainter, QImage,
+QRectF) instead of strings so mypy/pyright can resolve them while avoiding
+runtime imports.
+- Around line 1464-1471: The fallback printing loop silently skips non-Windows
+paths when 'lp' is absent; update the loop that iterates over fallback (the
+branch using platform.system(), os.startfile, shutil.which('lp') and _sp.Popen)
+to record any paths that cannot be printed (e.g., collect into a failed_paths
+list) and emit a warning after the loop (using the module logger or
+logging.warning) that includes those failed paths so users get feedback when
+'lp' is unavailable; ensure the Windows branch (os.startfile) remains unchanged
+and only non-Windows missing-'lp' cases are reported.
+- Around line 1428-1462: The QPainter 'painter' created for 'printer' must be
+closed in a finally block so painter.end() always runs; wrap the main rendering
+loop (the code iterating over 'renderable' that calls QPainter(printer),
+QImage(...), _draw_image_fitted and fitz.open) in try/finally and call
+painter.end() from the finally clause, and also ensure any opened fitz.Document
+(doc) is closed on error (either by using a with/context manager or closing doc
+in a nested finally) so neither the printer nor PDF handles are left open.
+```
+
+</details>
+
+<details>
+<summary>🪄 Autofix (Beta)</summary>
+
+Fix all unresolved CodeRabbit comments on this PR:
+
+- [ ] <!-- {"checkboxId": "4b0d0e0a-96d7-4f10-b296-3a18ea78f0b9"} --> Push a commit to this branch (recommended)
+- [ ] <!-- {"checkboxId": "ff5b1114-7d8c-49e6-8ac1-43f82af23a33"} --> Create a new PR with the fixes
+
+</details>
+
+---
+
+<details>
+<summary>ℹ️ Review info</summary>
+
+<details>
+<summary>⚙️ Run configuration</summary>
+
+**Configuration used**: Path: .coderabbit.yaml
+
+**Review profile**: CHILL
+
+**Plan**: Pro
+
+**Run ID**: `dde37edf-a7de-446b-a4c2-1a63b4595740`
+
+</details>
+
+<details>
+<summary>📥 Commits</summary>
+
+Reviewing files that changed from the base of the PR and between 7221b1e56b43f6e1f7f36c24e12d20cfa31c7d47 and 82176287af7b86b8cbbfc035ddbdb01fea9aefdd.
+
+</details>
+
+<details>
+<summary>⛔ Files ignored due to path filters (1)</summary>
+
+* `.claude/S&P.md` is excluded by `!.claude/S&P.md`
+
+</details>
+
+<details>
+<summary>📒 Files selected for processing (6)</summary>
+
+* `core/app_context.py`
+* `modules/job/module.py`
+* `modules/quote/module.py`
+* `modules/search/module.py`
+* `shared/utils.py`
+* `shared/widgets.py`
+
+</details>
+
+<details>
+<summary>🚧 Files skipped from review as they are similar to previous changes (3)</summary>
+
+* modules/search/module.py
+* modules/quote/module.py
+* modules/job/module.py
+
+</details>
+
+</details>
+
+<!-- This is an auto-generated comment by CodeRabbit for review status -->

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -5104,3 +5104,243 @@ Reviewing files that changed from the base of the PR and between 9b944bf956ca932
 </details>
 
 <!-- This is an auto-generated comment by CodeRabbit for review status -->
+
+---
+
+## 2026-04-16 — `PR #24: feat: batch print drawings from job/quote/search` — review run 1
+
+
+
+<details>
+<summary>🧹 Nitpick comments (3)</summary><blockquote>
+
+<details>
+<summary>shared/utils.py (2)</summary><blockquote>
+
+`189-189`: **Redundant import.**
+
+`subprocess` is now imported at module level (line 11), making this local import unnecessary.
+
+
+<details>
+<summary>🧹 Remove redundant import</summary>
+
+```diff
+ def open_folder(path: str) -> Tuple[bool, Optional[str]]:
+     """
+     Open a folder in the OS file browser.
+ 
+     Args:
+         path: Path to the folder to open
+ 
+     Returns:
+         Tuple of (success, error_message)
+     """
+-    import subprocess
+     try:
+         if platform.system() == "Windows":
+```
+</details>
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In `@shared/utils.py` at line 189, There is a redundant local "import subprocess"
+that duplicates the module-level import; remove the local import statement so
+the code uses the existing top-level subprocess import (search for the local
+"import subprocess" occurrence in shared/utils.py and delete it, leaving any
+functions or code that reference subprocess unchanged).
+```
+
+</details>
+
+---
+
+`206-214`: **Silent failures when printing files.**
+
+The function silently skips non-files and doesn't report errors if `os.startfile()` or `lp` fails. Users won't know if printing failed (e.g., `lp` not installed on Linux, permission denied, or unsupported file type).
+
+Consider returning status information or raising exceptions for critical failures.
+
+
+<details>
+<summary>♻️ Suggested improvement with basic error handling</summary>
+
+```diff
+-def print_files(paths: List[str]) -> None:
+-    """Send each file to the OS print handler (opens the system print dialog)."""
+-    for path in paths:
+-        if not os.path.isfile(path):
+-            continue
+-        if platform.system() == 'Windows':
+-            os.startfile(path, 'print')  # type: ignore[attr-defined]
+-        else:
+-            subprocess.Popen(['lp', path])
++def print_files(paths: List[str]) -> Tuple[int, List[str]]:
++    """Send each file to the OS print handler (opens the system print dialog).
++    
++    Returns:
++        Tuple of (success_count, list of error messages)
++    """
++    success = 0
++    errors = []
++    for path in paths:
++        if not os.path.isfile(path):
++            errors.append(f"Not a file: {path}")
++            continue
++        try:
++            if platform.system() == 'Windows':
++                os.startfile(path, 'print')  # type: ignore[attr-defined]
++            else:
++                subprocess.Popen(['lp', path])
++            success += 1
++        except FileNotFoundError:
++            errors.append(f"Print command not found (is 'lp' installed?)")
++        except OSError as e:
++            errors.append(f"Failed to print {path}: {e}")
++    return success, errors
+```
+</details>
+
+Note: The static analysis warnings (S603, S607) about subprocess security are low-risk here since paths originate from user-selected files that pass `os.path.isfile()` validation, but consider using `shutil.which('lp')` to verify availability before attempting to print on non-Windows systems.
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In `@shared/utils.py` around lines 206 - 214, The print_files function currently
+swallows non-files and printing errors; update print_files to validate
+availability of the print backend and report failures by returning per-path
+status or raising on critical errors: inside print_files, for each path
+(function print_files), if not os.path.isfile(path) record a failure status (or
+raise if that should be fatal); on Windows wrap os.startfile(path, 'print') in a
+try/except and capture/return the exception information; on non-Windows first
+check shutil.which('lp') and if missing return an informative failure for every
+path, otherwise call subprocess.Popen(['lp', path]) but capture exceptions (and
+subprocess errors) and return or raise the error; ensure the function signature
+and callers are adjusted to accept a mapping/list of results (e.g., path ->
+success/error) or document which exceptions are raised.
+```
+
+</details>
+
+</blockquote></details>
+<details>
+<summary>modules/search/module.py (1)</summary><blockquote>
+
+`759-764`: **Minor UX consideration: Context menu visibility depends on clicked item.**
+
+The "Print Selected" action only appears when right-clicking on a file item (line 759: `if is_file:`). If a user has multiple files selected but right-clicks on a folder row, the print option won't appear.
+
+This is a minor edge case and the current behavior is acceptable, but you could consider showing "Print Selected" whenever there's at least one file in the selection.
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In `@modules/search/module.py` around lines 759 - 764, The context menu currently
+adds "Print Selected" only when the clicked row is a file (controlled by
+is_file); change this to show the action whenever the current selection contains
+at least one file. Inside the context-menu construction (the block that checks
+is_file and adds print_action), replace the is_file-only check with a
+selection-based check that inspects the view/model selection (use the same
+selection APIs you already use elsewhere in this class) to determine if any
+selected item is a file, and if so call menu.addAction("Print Selected") and
+connect it to _print_selected_folder_files; keep the existing "Blueprints Path"
+logic and lambda to _blueprints_path_action(path) unchanged.
+```
+
+</details>
+
+</blockquote></details>
+
+</blockquote></details>
+
+<details>
+<summary>🤖 Prompt for all review comments with AI agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+Nitpick comments:
+In `@modules/search/module.py`:
+- Around line 759-764: The context menu currently adds "Print Selected" only
+when the clicked row is a file (controlled by is_file); change this to show the
+action whenever the current selection contains at least one file. Inside the
+context-menu construction (the block that checks is_file and adds print_action),
+replace the is_file-only check with a selection-based check that inspects the
+view/model selection (use the same selection APIs you already use elsewhere in
+this class) to determine if any selected item is a file, and if so call
+menu.addAction("Print Selected") and connect it to _print_selected_folder_files;
+keep the existing "Blueprints Path" logic and lambda to
+_blueprints_path_action(path) unchanged.
+
+In `@shared/utils.py`:
+- Line 189: There is a redundant local "import subprocess" that duplicates the
+module-level import; remove the local import statement so the code uses the
+existing top-level subprocess import (search for the local "import subprocess"
+occurrence in shared/utils.py and delete it, leaving any functions or code that
+reference subprocess unchanged).
+- Around line 206-214: The print_files function currently swallows non-files and
+printing errors; update print_files to validate availability of the print
+backend and report failures by returning per-path status or raising on critical
+errors: inside print_files, for each path (function print_files), if not
+os.path.isfile(path) record a failure status (or raise if that should be fatal);
+on Windows wrap os.startfile(path, 'print') in a try/except and capture/return
+the exception information; on non-Windows first check shutil.which('lp') and if
+missing return an informative failure for every path, otherwise call
+subprocess.Popen(['lp', path]) but capture exceptions (and subprocess errors)
+and return or raise the error; ensure the function signature and callers are
+adjusted to accept a mapping/list of results (e.g., path -> success/error) or
+document which exceptions are raised.
+```
+
+</details>
+
+---
+
+<details>
+<summary>ℹ️ Review info</summary>
+
+<details>
+<summary>⚙️ Run configuration</summary>
+
+**Configuration used**: Path: .coderabbit.yaml
+
+**Review profile**: CHILL
+
+**Plan**: Pro
+
+**Run ID**: `cb1eaf8e-bef8-4c5d-ab08-127c7fc2b616`
+
+</details>
+
+<details>
+<summary>📥 Commits</summary>
+
+Reviewing files that changed from the base of the PR and between 31d95fdc9858f9d0986f681c14cb7a3766eea4d3 and 7221b1e56b43f6e1f7f36c24e12d20cfa31c7d47.
+
+</details>
+
+<details>
+<summary>📒 Files selected for processing (6)</summary>
+
+* `modules/job/module.py`
+* `modules/job/ui/job_tab.ui`
+* `modules/quote/module.py`
+* `modules/quote/ui/quote_tab.ui`
+* `modules/search/module.py`
+* `shared/utils.py`
+
+</details>
+
+</details>
+
+<!-- This is an auto-generated comment by CodeRabbit for review status -->

--- a/core/app_context.py
+++ b/core/app_context.py
@@ -62,6 +62,7 @@ class AppContext:
         self._get_customer_list = get_customer_list_callback
         self._add_to_history = add_to_history_callback
         self._main_window = main_window
+        self._print_provider = None
 
     @property
     def settings(self) -> Dict[str, Any]:
@@ -82,6 +83,19 @@ class AppContext:
     def main_window(self) -> Optional[Any]:
         """Get reference to main window (use sparingly)"""
         return self._main_window
+
+    def register_print_provider(self, provider) -> None:
+        """Register a plugin as the active print provider.
+
+        The provider must implement add_files_to_list(paths: list).
+        If a provider is registered, print_files_with_dialog() delegates to it
+        instead of using the built-in QPrintDialog.
+        """
+        self._print_provider = provider
+
+    def get_print_provider(self):
+        """Return the registered print provider, or None."""
+        return self._print_provider
 
     def save_settings(self):
         """Save application settings to disk"""

--- a/modules/job/module.py
+++ b/modules/job/module.py
@@ -21,10 +21,10 @@ from PyQt6 import uic
 from datetime import datetime
 
 from core.base_module import BaseModule
-from shared.widgets import DropZone, JobSearchDialog, DrawingSearchDialog, FilePreviewWidget, attach_file_preview
+from shared.widgets import DropZone, JobSearchDialog, DrawingSearchDialog, FilePreviewWidget, attach_file_preview, print_files_with_dialog
 from shared.utils import (
     is_blueprint_file, parse_job_numbers, create_file_link,
-    sanitize_filename, open_folder, get_next_number, print_files
+    sanitize_filename, open_folder, get_next_number
 )
 
 
@@ -315,7 +315,7 @@ class JobModule(BaseModule):
         rows = sorted({i.row() for i in self.job_files_list.selectedIndexes()})
         paths = [self.job_files[r] for r in rows if 0 <= r < len(self.job_files)]
         if paths:
-            print_files(paths)
+            print_files_with_dialog(paths, self._widget, self.app_context)
 
     # ==================== Create New Tab: Job Creation ====================
 
@@ -774,7 +774,7 @@ class JobModule(BaseModule):
         rows = sorted({i.row() for i in self.add_files_list.selectedIndexes()})
         paths = [self.add_files[r] for r in rows if 0 <= r < len(self.add_files)]
         if paths:
-            print_files(paths)
+            print_files_with_dialog(paths, self._widget, self.app_context)
 
     def clear_add_files(self):
         """Clear all files from add files list"""

--- a/modules/job/module.py
+++ b/modules/job/module.py
@@ -13,7 +13,7 @@ import shutil
 from pathlib import Path
 from typing import List, Type
 from PyQt6.QtWidgets import (
-    QWidget, QMessageBox, QTreeWidgetItem, QButtonGroup, QCheckBox
+    QWidget, QMessageBox, QTreeWidgetItem, QButtonGroup, QCheckBox, QAbstractItemView
 )
 
 from PyQt6.QtCore import Qt, QThread, pyqtSignal
@@ -24,7 +24,7 @@ from core.base_module import BaseModule
 from shared.widgets import DropZone, JobSearchDialog, DrawingSearchDialog, FilePreviewWidget, attach_file_preview
 from shared.utils import (
     is_blueprint_file, parse_job_numbers, create_file_link,
-    sanitize_filename, open_folder, get_next_number
+    sanitize_filename, open_folder, get_next_number, print_files
 )
 
 
@@ -156,6 +156,7 @@ class JobModule(BaseModule):
         self.drawings_edit = widget.drawings_edit
         self.itar_check = widget.itar_check
         self.job_files_list = widget.job_files_list
+        self.job_files_list.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
 
         # Replace DropZone placeholder for Create tab
         placeholder = widget.job_drop_zone
@@ -174,6 +175,7 @@ class JobModule(BaseModule):
         # Connect Create New tab signals
         self.job_drop_zone.files_dropped.connect(lambda files: self.handle_job_files(files))
         widget.remove_btn.clicked.connect(self.remove_job_file)
+        widget.print_btn.clicked.connect(self.print_job_files)
         widget.copy_from_btn.clicked.connect(self.show_copy_from_dialog)
         widget.link_drawings_btn.clicked.connect(self.show_link_drawings_dialog)
         widget.create_btn.clicked.connect(self.create_job)
@@ -189,6 +191,7 @@ class JobModule(BaseModule):
         self.job_tree = widget.job_tree
         self.selected_job_label = widget.selected_job_label
         self.add_files_list = widget.add_files_list
+        self.add_files_list.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
         self.add_status_label = widget.add_status_label
 
         # Store radio button references
@@ -239,6 +242,7 @@ class JobModule(BaseModule):
         self.add_drop_zone.files_dropped.connect(lambda files: self.handle_add_files(files))
         widget.remove_add_btn.clicked.connect(self.remove_add_file)
         widget.clear_add_btn.clicked.connect(self.clear_add_files)
+        widget.print_add_btn.clicked.connect(self.print_add_files)
         widget.add_files_btn.clicked.connect(self.add_files_to_job)
 
         return widget
@@ -305,6 +309,13 @@ class JobModule(BaseModule):
         if row >= 0:
             self.job_files_list.takeItem(row)
             del self.job_files[row]
+
+    def print_job_files(self):
+        """Print all selected files in the Create New tab file list."""
+        rows = sorted({i.row() for i in self.job_files_list.selectedIndexes()})
+        paths = [self.job_files[r] for r in rows if 0 <= r < len(self.job_files)]
+        if paths:
+            print_files(paths)
 
     # ==================== Create New Tab: Job Creation ====================
 
@@ -757,6 +768,13 @@ class JobModule(BaseModule):
         if row >= 0:
             self.add_files_list.takeItem(row)
             del self.add_files[row]
+
+    def print_add_files(self):
+        """Print all selected files in the Add to Existing tab file list."""
+        rows = sorted({i.row() for i in self.add_files_list.selectedIndexes()})
+        paths = [self.add_files[r] for r in rows if 0 <= r < len(self.add_files)]
+        if paths:
+            print_files(paths)
 
     def clear_add_files(self):
         """Clear all files from add files list"""

--- a/modules/job/ui/job_tab.ui
+++ b/modules/job/ui/job_tab.ui
@@ -263,6 +263,13 @@
              </widget>
             </item>
             <item>
+             <widget class="QPushButton" name="print_btn">
+              <property name="text">
+               <string>Print Selected</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <spacer name="horizontalSpacer">
               <property name="orientation">
                <enum>Qt::Orientation::Horizontal</enum>
@@ -659,6 +666,13 @@
                  <widget class="QPushButton" name="clear_add_btn">
                   <property name="text">
                    <string>Clear All</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="print_add_btn">
+                  <property name="text">
+                   <string>Print Selected</string>
                   </property>
                  </widget>
                 </item>

--- a/modules/quote/module.py
+++ b/modules/quote/module.py
@@ -13,7 +13,7 @@ import shutil
 from pathlib import Path
 from typing import List
 from PyQt6.QtWidgets import (
-    QWidget, QMessageBox, QFileDialog, QTreeWidgetItem, QButtonGroup, QCheckBox
+    QWidget, QMessageBox, QFileDialog, QTreeWidgetItem, QButtonGroup, QCheckBox, QAbstractItemView
 )
 from PyQt6.QtCore import Qt, QTimer, QThread, pyqtSignal
 from PyQt6 import uic
@@ -23,7 +23,7 @@ from core.base_module import BaseModule
 from shared.widgets import DropZone, JobSearchDialog, DrawingSearchDialog, FilePreviewWidget, attach_file_preview
 from shared.utils import (
     is_blueprint_file, parse_job_numbers, create_file_link, sanitize_filename,
-    open_folder, get_next_number
+    open_folder, get_next_number, print_files
 )
 
 
@@ -151,6 +151,7 @@ class QuoteModule(BaseModule):
         self.quote_drawings_edit = widget.quote_drawings_edit
         self.quote_itar_check = widget.quote_itar_check
         self.quote_files_list = widget.quote_files_list
+        self.quote_files_list.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
 
         # Replace QFrame placeholder with actual DropZone widget
         placeholder = widget.quote_drop_zone
@@ -169,6 +170,7 @@ class QuoteModule(BaseModule):
         # Connect Create New tab signals
         self.quote_drop_zone.files_dropped.connect(lambda files: self.add_quote_files(files))
         widget.remove_btn.clicked.connect(self.remove_quote_file)
+        widget.print_btn.clicked.connect(self.print_quote_files)
         widget.copy_from_btn.clicked.connect(self.show_copy_from_dialog)
         widget.link_drawings_btn.clicked.connect(self.show_link_drawings_dialog)
         widget.create_btn.clicked.connect(self.create_quote)
@@ -184,6 +186,7 @@ class QuoteModule(BaseModule):
         self.quote_tree = widget.quote_tree
         self.selected_quote_label = widget.selected_quote_label
         self.add_files_list = widget.add_files_list
+        self.add_files_list.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
         self.add_status_label = widget.add_status_label
 
         # Store radio button references
@@ -234,6 +237,7 @@ class QuoteModule(BaseModule):
         self.add_drop_zone.files_dropped.connect(lambda files: self.handle_add_files(files))
         widget.remove_add_btn.clicked.connect(self.remove_add_file)
         widget.clear_add_btn.clicked.connect(self.clear_add_files)
+        widget.print_add_btn.clicked.connect(self.print_add_files)
         widget.add_files_btn.clicked.connect(self.add_files_to_quote)
 
         return widget
@@ -309,6 +313,13 @@ class QuoteModule(BaseModule):
             # Update preview for the new selection (or clear if list is now empty)
             new_row = self.quote_files_list.currentRow()
             self._on_quote_file_selected(new_row)
+
+    def print_quote_files(self):
+        """Print all selected files in the Create New tab file list."""
+        rows = sorted({i.row() for i in self.quote_files_list.selectedIndexes()})
+        paths = [self.quote_files[r] for r in rows if 0 <= r < len(self.quote_files)]
+        if paths:
+            print_files(paths)
 
     def _on_quote_file_selected(self, row: int):
         if self.quote_preview is None:
@@ -714,6 +725,13 @@ class QuoteModule(BaseModule):
         if row >= 0:
             self.add_files_list.takeItem(row)
             del self.add_files[row]
+
+    def print_add_files(self):
+        """Print all selected files in the Add to Existing tab file list."""
+        rows = sorted({i.row() for i in self.add_files_list.selectedIndexes()})
+        paths = [self.add_files[r] for r in rows if 0 <= r < len(self.add_files)]
+        if paths:
+            print_files(paths)
 
     def clear_add_files(self):
         """Clear all files from add files list"""

--- a/modules/quote/module.py
+++ b/modules/quote/module.py
@@ -20,10 +20,10 @@ from PyQt6 import uic
 from datetime import datetime
 
 from core.base_module import BaseModule
-from shared.widgets import DropZone, JobSearchDialog, DrawingSearchDialog, FilePreviewWidget, attach_file_preview
+from shared.widgets import DropZone, JobSearchDialog, DrawingSearchDialog, FilePreviewWidget, attach_file_preview, print_files_with_dialog
 from shared.utils import (
     is_blueprint_file, parse_job_numbers, create_file_link, sanitize_filename,
-    open_folder, get_next_number, print_files
+    open_folder, get_next_number
 )
 
 
@@ -319,7 +319,7 @@ class QuoteModule(BaseModule):
         rows = sorted({i.row() for i in self.quote_files_list.selectedIndexes()})
         paths = [self.quote_files[r] for r in rows if 0 <= r < len(self.quote_files)]
         if paths:
-            print_files(paths)
+            print_files_with_dialog(paths, self._widget, self.app_context)
 
     def _on_quote_file_selected(self, row: int):
         if self.quote_preview is None:
@@ -731,7 +731,7 @@ class QuoteModule(BaseModule):
         rows = sorted({i.row() for i in self.add_files_list.selectedIndexes()})
         paths = [self.add_files[r] for r in rows if 0 <= r < len(self.add_files)]
         if paths:
-            print_files(paths)
+            print_files_with_dialog(paths, self._widget, self.app_context)
 
     def clear_add_files(self):
         """Clear all files from add files list"""

--- a/modules/quote/ui/quote_tab.ui
+++ b/modules/quote/ui/quote_tab.ui
@@ -249,6 +249,13 @@
              </widget>
             </item>
             <item>
+             <widget class="QPushButton" name="print_btn">
+              <property name="text">
+               <string>Print Selected</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <spacer name="horizontalSpacer">
               <property name="orientation">
                <enum>Qt::Orientation::Horizontal</enum>
@@ -642,6 +649,13 @@
                  <widget class="QPushButton" name="clear_add_btn">
                   <property name="text">
                    <string>Clear All</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="print_add_btn">
+                  <property name="text">
+                   <string>Print Selected</string>
                   </property>
                  </widget>
                 </item>

--- a/modules/search/module.py
+++ b/modules/search/module.py
@@ -23,7 +23,8 @@ from PyQt6.QtGui import QDesktopServices
 from PyQt6 import uic
 
 from core.base_module import BaseModule
-from shared.utils import open_folder, print_files
+from shared.utils import open_folder
+from shared.widgets import print_files_with_dialog
 
 
 def _is_hidden_file(full_path: str, name: str) -> bool:
@@ -773,7 +774,7 @@ class SearchModule(BaseModule):
             if os.path.isfile(item.data(Qt.ItemDataRole.UserRole) or '')
         ]
         if paths:
-            print_files(paths)
+            print_files_with_dialog(paths, self._widget, self.app_context)
 
     def _get_customer_bp_info(self):
         """Return (customer_name, blueprints_dir) for the currently selected search result."""

--- a/modules/search/module.py
+++ b/modules/search/module.py
@@ -23,7 +23,7 @@ from PyQt6.QtGui import QDesktopServices
 from PyQt6 import uic
 
 from core.base_module import BaseModule
-from shared.utils import open_folder
+from shared.utils import open_folder, print_files
 
 
 def _is_hidden_file(full_path: str, name: str) -> bool:
@@ -360,6 +360,7 @@ class SearchModule(BaseModule):
         folder_layout.setContentsMargins(5, 5, 5, 5)
         self.folder_contents_list = QListWidget()
         self.folder_contents_list.setAlternatingRowColors(True)
+        self.folder_contents_list.setSelectionMode(QListWidget.SelectionMode.ExtendedSelection)
 
         self.file_preview = FilePreviewWidget()
         self.file_preview.setMinimumHeight(80)
@@ -757,10 +758,22 @@ class SearchModule(BaseModule):
 
         if is_file:
             menu.addSeparator()
+            print_action = menu.addAction("Print Selected")
+            print_action.triggered.connect(self._print_selected_folder_files)
             bp_action = menu.addAction("Blueprints Path")
             bp_action.triggered.connect(lambda: self._blueprints_path_action(path))
 
         menu.exec(self.folder_contents_list.viewport().mapToGlobal(pos))
+
+    def _print_selected_folder_files(self):
+        """Print all selected files from the folder contents list."""
+        paths = [
+            item.data(Qt.ItemDataRole.UserRole)
+            for item in self.folder_contents_list.selectedItems()
+            if os.path.isfile(item.data(Qt.ItemDataRole.UserRole) or '')
+        ]
+        if paths:
+            print_files(paths)
 
     def _get_customer_bp_info(self):
         """Return (customer_name, blueprints_dir) for the currently selected search result."""

--- a/shared/utils.py
+++ b/shared/utils.py
@@ -186,7 +186,6 @@ def open_folder(path: str) -> Tuple[bool, Optional[str]]:
     Returns:
         Tuple of (success, error_message)
     """
-    import subprocess
     try:
         if platform.system() == "Windows":
             os.startfile(path)
@@ -211,7 +210,9 @@ def print_files(paths: List[str]) -> None:
         if platform.system() == 'Windows':
             os.startfile(path, 'print')  # type: ignore[attr-defined]
         else:
-            subprocess.Popen(['lp', path])
+            lp = shutil.which('lp')
+            if lp:
+                subprocess.Popen([lp, path])
 
 
 def get_next_number(history: Dict[str, Any], entry_type: str, start_number: int = 10000) -> str:

--- a/shared/utils.py
+++ b/shared/utils.py
@@ -8,6 +8,7 @@ import os
 import platform
 import shutil
 import re
+import subprocess
 from pathlib import Path
 from typing import Dict, Any, List, Tuple, Optional
 
@@ -200,6 +201,17 @@ def open_folder(path: str) -> Tuple[bool, Optional[str]]:
         return False, f"Permission denied: {path}"
     except Exception as e:
         return False, f"Failed to open folder: {e}"
+
+
+def print_files(paths: List[str]) -> None:
+    """Send each file to the OS print handler (opens the system print dialog)."""
+    for path in paths:
+        if not os.path.isfile(path):
+            continue
+        if platform.system() == 'Windows':
+            os.startfile(path, 'print')  # type: ignore[attr-defined]
+        else:
+            subprocess.Popen(['lp', path])
 
 
 def get_next_number(history: Dict[str, Any], entry_type: str, start_number: int = 10000) -> str:

--- a/shared/utils.py
+++ b/shared/utils.py
@@ -4,6 +4,7 @@ Shared utility functions for JobDocs
 Common helper functions used across multiple modules.
 """
 
+import logging
 import os
 import platform
 import shutil
@@ -11,6 +12,8 @@ import re
 import subprocess
 from pathlib import Path
 from typing import Dict, Any, List, Tuple, Optional
+
+logger = logging.getLogger(__name__)
 
 
 def get_config_dir() -> Path:
@@ -213,6 +216,8 @@ def print_files(paths: List[str]) -> None:
             lp = shutil.which('lp')
             if lp:
                 subprocess.Popen([lp, path])
+            else:
+                logger.warning("print_files: 'lp' not found — cannot print %s", path)
 
 
 def get_next_number(history: Dict[str, Any], entry_type: str, start_number: int = 10000) -> str:

--- a/shared/widgets.py
+++ b/shared/widgets.py
@@ -1461,14 +1461,25 @@ def print_files_with_dialog(paths: list, parent=None, app_context=None) -> None:
 
         painter.end()
 
+    import subprocess as _sp
+    lp = shutil.which('lp') if platform.system() != 'Windows' else None
+    unprinted: list[str] = []
+
     for path in fallback:
         if platform.system() == 'Windows':
             os.startfile(path, 'print')  # type: ignore[attr-defined]
+        elif lp:
+            _sp.Popen([lp, path])
         else:
-            import subprocess as _sp
-            lp = shutil.which('lp')
-            if lp:
-                _sp.Popen([lp, path])
+            unprinted.append(os.path.basename(path))
+
+    if unprinted:
+        from PyQt6.QtWidgets import QMessageBox
+        names = '\n'.join(f'  • {n}' for n in unprinted)
+        QMessageBox.warning(
+            parent, "Print",
+            f"The following file(s) could not be printed — 'lp' was not found on this system:\n\n{names}"
+        )
 
 
 def attach_file_preview(

--- a/shared/widgets.py
+++ b/shared/widgets.py
@@ -1465,8 +1465,10 @@ def print_files_with_dialog(paths: list, parent=None, app_context=None) -> None:
         if platform.system() == 'Windows':
             os.startfile(path, 'print')  # type: ignore[attr-defined]
         else:
-            import subprocess
-            subprocess.Popen(['lp', path])
+            import subprocess as _sp
+            lp = shutil.which('lp')
+            if lp:
+                _sp.Popen([lp, path])
 
 
 def attach_file_preview(

--- a/shared/widgets.py
+++ b/shared/widgets.py
@@ -1377,6 +1377,98 @@ class FilePreviewWidget(QWidget):
         raise AssertionError("unreachable")
 
 
+def _draw_image_fitted(painter: 'QPainter', img: 'QImage', page_rect: 'QRectF') -> None:  # type: ignore[name-defined]
+    """Draw img centred and scaled to fit page_rect preserving aspect ratio."""
+    from PyQt6.QtCore import QRectF as _QRectF
+    img_ratio = img.width() / max(img.height(), 1)
+    page_ratio = page_rect.width() / max(page_rect.height(), 1)
+    if img_ratio > page_ratio:
+        w = page_rect.width()
+        h = w / img_ratio
+    else:
+        h = page_rect.height()
+        w = h * img_ratio
+    x = (page_rect.width() - w) / 2
+    y = (page_rect.height() - h) / 2
+    painter.drawImage(_QRectF(x, y, w, h), img)
+
+
+def print_files_with_dialog(paths: list, parent=None, app_context=None) -> None:
+    """Show a print dialog then render and print each file.
+
+    If a print provider is registered via app_context.register_print_provider()
+    (e.g. the HoneyBatchr plugin), files are sent there instead.
+
+    Otherwise: PDF files are rendered via PyMuPDF (fitz); common image formats
+    are loaded directly; other types (DWG, DXF, etc.) fall back to the OS print
+    handler (os.startfile on Windows, lp on macOS/Linux).
+    """
+    if app_context is not None:
+        provider = app_context.get_print_provider()
+        if provider is not None:
+            provider.add_files_to_list(paths)
+            return
+    import platform
+    from PyQt6.QtPrintSupport import QPrinter, QPrintDialog
+    from PyQt6.QtGui import QPainter, QImage
+    from PyQt6.QtCore import QRectF
+
+    _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.gif', '.bmp', '.tiff', '.tif', '.webp'}
+    _RENDERABLE = _IMAGE_EXTS | {'.pdf'}
+
+    renderable = [p for p in paths if os.path.isfile(p) and Path(p).suffix.lower() in _RENDERABLE]
+    fallback   = [p for p in paths if os.path.isfile(p) and Path(p).suffix.lower() not in _RENDERABLE]
+
+    if renderable:
+        printer = QPrinter(QPrinter.PrinterMode.HighResolution)
+        dlg = QPrintDialog(printer, parent)
+        if dlg.exec() != QPrintDialog.DialogCode.Accepted:
+            return  # cancelled — skip fallback too
+
+        painter = QPainter(printer)
+        page_rect = QRectF(painter.viewport())
+        first = True
+
+        for path in renderable:
+            ext = Path(path).suffix.lower()
+            if ext == '.pdf':
+                try:
+                    import fitz  # pymupdf
+                    doc = fitz.open(path)
+                    for page_num in range(doc.page_count):
+                        if not first:
+                            printer.newPage()
+                            page_rect = QRectF(painter.viewport())
+                        first = False
+                        pg = doc[page_num]
+                        zoom = 200 / 72  # render at 200 DPI
+                        pix = pg.get_pixmap(matrix=fitz.Matrix(zoom, zoom), alpha=False)
+                        samples = bytes(pix.samples)
+                        img = QImage(samples, pix.width, pix.height,
+                                     pix.stride, QImage.Format.Format_RGB888).copy()
+                        _draw_image_fitted(painter, img, page_rect)
+                    doc.close()
+                except ImportError:
+                    fallback.append(path)
+            else:
+                if not first:
+                    printer.newPage()
+                    page_rect = QRectF(painter.viewport())
+                first = False
+                img = QImage(path)
+                if not img.isNull():
+                    _draw_image_fitted(painter, img, page_rect)
+
+        painter.end()
+
+    for path in fallback:
+        if platform.system() == 'Windows':
+            os.startfile(path, 'print')  # type: ignore[attr-defined]
+        else:
+            import subprocess
+            subprocess.Popen(['lp', path])
+
+
 def attach_file_preview(
     files_list,
     parent_layout,


### PR DESCRIPTION
## Summary
- **`shared/utils.print_files()`**: New utility — `os.startfile(path, 'print')` on Windows (opens system print dialog via the default app), falls back to `lp` on macOS/Linux.
- **Job/Quote tabs**: "Print Selected" button added next to "Remove Selected" on both Create New and Add to Existing tabs. File lists now support Ctrl/Shift+click multi-select.
- **Search folder contents**: "Print Selected" added to right-click context menu. Multi-select (Ctrl/Shift+click) enabled.

## Test plan
- [ ] Drop multiple PDFs into a job, Ctrl+click to select several, press Print Selected — system print dialog opens for each
- [ ] Same test on Quote tab (Create New and Add to Existing)
- [ ] In Search, browse a job folder, Ctrl+click to select files, right-click → Print Selected
- [ ] Pressing Print Selected with nothing selected does nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Print Selected" buttons in Job and Quote file tabs to print multiple selected files.
  * Added "Print Selected" option to the search context menu for folder/file results.
  * Enabled multi-file selection across file lists for batch printing.
  * Added a unified print dialog that renders images/PDFs before printing and supports external print providers and cross-platform printing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->