### PR TITLE
ci: fix log-coderabbit workflow YAML parse error and add Node.js 24 flag

### DIFF
--- a/.github/workflows/log-coderabbit-review.yml
+++ b/.github/workflows/log-coderabbit-review.yml
@@ -4,6 +4,11 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Opt into Node.js 24 for all actions until upstream releases Node.js 24-native
+# versions. Remove once all actions are updated (deadline: 2026-06-02).
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   log-review:
     if: github.event.review.user.login == 'coderabbitai[bot]'
@@ -33,26 +38,21 @@ jobs:
             | grep -oE '[0-9]+$' | sort -n | tail -1)
           RUN_NUM=$(( ${MAX_RUN:-0} + 1 ))
 
-          # Extract just the actionable/nitpick summary line and finding titles
-          SUMMARY=$(echo "$REVIEW_BODY" | python3 -c "
-import sys, re
-body = sys.stdin.read()
-# Pull the top-level summary line
-m = re.search(r'\*\*Actionable comments posted: (\d+)\*\*', body)
-actionable = m.group(1) if m else '?'
-m2 = re.search(r'Nitpick comments \((\d+)\)', body)
-nitpicks = m2.group(1) if m2 else '0'
-
-# Pull finding titles (bold lines with line refs)
-titles = re.findall(r'\*\*(.{10,80}?)\*\*', body)
-# Filter to likely finding titles (contain a verb or colon, skip nav/meta)
-skip = {'Duplicate comments','Nitpick comments','Actionable comments','Suggested','Proposed','Actions performed'}
-findings = [t for t in titles if not any(s in t for s in skip) and len(t) > 15][:6]
-
-print(f'Actionable: {actionable}  Nitpicks: {nitpicks}')
-for f in findings:
-    print(f'- {f}')
-")
+          python3 - > /tmp/cr_summary.txt << 'PYEOF'
+          import re, os
+          body = os.environ.get('REVIEW_BODY', '')
+          m = re.search(r'\*\*Actionable comments posted: (\d+)\*\*', body)
+          actionable = m.group(1) if m else '?'
+          m2 = re.search(r'Nitpick comments \((\d+)\)', body)
+          nitpicks = m2.group(1) if m2 else '0'
+          titles = re.findall(r'\*\*(.{10,80}?)\*\*', body)
+          skip = {'Duplicate comments','Nitpick comments','Actionable comments','Suggested','Proposed','Actions performed'}
+          findings = [t for t in titles if not any(s in t for s in skip) and len(t) > 15][:6]
+          print(f'Actionable: {actionable}  Nitpicks: {nitpicks}')
+          for f in findings:
+              print(f'- {f}')
+          PYEOF
+          SUMMARY=$(cat /tmp/cr_summary.txt)
 
           printf '\n---\n\n## %s — `%s` — run %d\n\n%s\n' \
             "$DATE" "$PR_REF" "$RUN_NUM" "$SUMMARY" >> ".claude/S&P.md"


### PR DESCRIPTION
## Summary
- Replaces unindented `python3 -c "..."` inline script with a properly-indented heredoc (`python3 - << 'PYEOF'`) so YAML parses the `run: |` block correctly
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` env var to suppress the Node.js 20 deprecation warning on `actions/checkout@v4`

The YAML parse fix was made on `feat/print-preview` after PR #25 was already merged, so it never landed on `stable`. This PR backports it.

## Test plan
- [ ] Push a review comment trigger — workflow runs without parse error
- [ ] No Node.js 20 deprecation warning in run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)