### PR TITLE
fix: show correct version in GNOME Software instead of "master"

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -239,7 +239,7 @@ jobs:
 
       - name: Inject version into metainfo
         run: |
-          VERSION="${{ github.ref_name }}"
+          VERSION="${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}"
           VERSION="${VERSION#v}"
           DATE="$(date -u +%Y-%m-%d)"
           sed -i "s/@VERSION@/${VERSION}/g; s/@DATE@/${DATE}/g" \

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -237,6 +237,14 @@ jobs:
           cp -r dist/JobDocs linux/flatpak/JobDocs_dir
           cp JobDocs.iconset/icon_256x256.png linux/flatpak/icon_256x256.png
 
+      - name: Inject version into metainfo
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          DATE="$(date -u +%Y-%m-%d)"
+          sed -i "s/@VERSION@/${VERSION}/g; s/@DATE@/${DATE}/g" \
+            linux/flatpak/io.github.i_machine_things.JobDocs.metainfo.xml
+
       - name: Build Flatpak
         run: |
           flatpak-builder \
@@ -247,6 +255,7 @@ jobs:
             linux/flatpak/io.github.i_machine_things.JobDocs.yml
           flatpak build-bundle \
             --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo \
+            --default-branch=stable \
             flatpak-repo \
             JobDocs-linux.flatpak \
             io.github.i_machine_things.JobDocs

--- a/linux/flatpak/io.github.i_machine_things.JobDocs.metainfo.xml
+++ b/linux/flatpak/io.github.i_machine_things.JobDocs.metainfo.xml
@@ -34,4 +34,8 @@
   </provides>
 
   <content_rating type="oars-1.1"/>
+
+  <releases>
+    <release version="@VERSION@" date="@DATE@"/>
+  </releases>
 </component>


### PR DESCRIPTION
## Summary
- GNOME Software displayed "Version: master" because the metainfo.xml had no `<releases>` block and `flatpak build-bundle` defaulted its branch to "master"
- Added `<releases>` to metainfo.xml with `@VERSION@`/`@DATE@` placeholders
- CI now injects the tag version and date via `sed` before `flatpak-builder` runs
- Added `--default-branch=stable` to `flatpak build-bundle`

## Test plan
- [ ] Trigger a `workflow_dispatch` build and install the `.flatpak` — GNOME Software should show the correct version number
- [ ] Verify metainfo placeholder is replaced correctly in CI logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)