### PR TITLE
fix: auto job/quote numbers scan CF and BP dirs for existing numbers

### DIFF
--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -1998,4 +1998,12 @@ Actionable: ?  Nitpicks: 3
 - Harden tag lookup for repos with mixed/no tags.
 - Graceful degradation is reasonable; consider a one-time user hint.
 - Prefer objectName/shortcut over the broad text substring match.
+
+---
+
+## 2026-04-18 — `PR #34: fix: auto job/quote numbers scan CF and BP dirs for existing numbers` — run 1
+
+Actionable: 2  Nitpicks: 2
+- Clarify the version computation step in the example.
+- Specify the expected action when checking thresholds.
 - Configuration used

--- a/core/settings_dialog.py
+++ b/core/settings_dialog.py
@@ -28,9 +28,11 @@ class SettingsDialog(QDialog):
 
     def __init__(self, settings: Dict[str, Any], parent=None,
                  available_modules: Optional[List[tuple]] = None,
-                 save_callback: Optional[Callable[..., Any]] = None):
+                 save_callback: Optional[Callable[..., Any]] = None,
+                 active_keys: Optional[set] = None):
         super().__init__(parent)
         self.settings = settings.copy()
+        self._active_keys = active_keys  # keys present in DEFAULT_SETTINGS; None means show all
         self.available_modules = available_modules or []  # List of (module_name, display_name) tuples
         self.module_checkboxes = {}  # Store module checkboxes
         self._save_callback = save_callback  # Called to persist settings to disk mid-dialog
@@ -256,10 +258,12 @@ class SettingsDialog(QDialog):
         )
         advanced_content_layout.addWidget(self.job_structure_edit)
 
-        advanced_content_layout.addWidget(QLabel(""))
-
-        advanced_content_layout.addWidget(QLabel("Quote Folder Path:"))
+        _quote_label = QLabel("Quote Folder Path:")
         self.quote_folder_edit = QLineEdit(self.settings.get('quote_folder_path', 'Quotes'))
+        _quote_visible = self._active_keys is None or 'quote_folder_path' in self._active_keys
+        _quote_label.setVisible(_quote_visible)
+        self.quote_folder_edit.setVisible(_quote_visible)
+        advanced_content_layout.addWidget(_quote_label)
         advanced_content_layout.addWidget(self.quote_folder_edit)
 
         advanced_content_layout.addWidget(QLabel(""))
@@ -268,11 +272,11 @@ class SettingsDialog(QDialog):
         self.legacy_mode_check.setChecked(self.settings.get('legacy_mode', True))
         advanced_content_layout.addWidget(self.legacy_mode_check)
 
-        advanced_content_layout.addWidget(QLabel(""))
-
         self.experimental_check = QCheckBox("Enable experimental features (Reporting)")
         self.experimental_check.setChecked(self.settings.get('experimental_features', False))
         self.experimental_check.setToolTip("Enables experimental features. Requires restart.")
+        _exp_visible = self._active_keys is None or 'experimental_features' in self._active_keys
+        self.experimental_check.setVisible(_exp_visible)
         advanced_content_layout.addWidget(self.experimental_check)
 
         advanced_layout.addWidget(self.advanced_content)
@@ -317,7 +321,8 @@ class SettingsDialog(QDialog):
         self.settings['blueprint_extensions'] = extensions
 
         self.settings['job_folder_structure'] = self.job_structure_edit.text().strip()
-        self.settings['quote_folder_path'] = self.quote_folder_edit.text().strip()
+        if self.quote_folder_edit.isVisible():
+            self.settings['quote_folder_path'] = self.quote_folder_edit.text().strip()
         self.settings['legacy_mode'] = self.legacy_mode_check.isChecked()
         self.settings['allow_duplicate_jobs'] = self.allow_duplicates_check.isChecked()
         self.settings['skip_image_attachments'] = self.skip_images_check.isChecked()
@@ -325,7 +330,8 @@ class SettingsDialog(QDialog):
         idx = self.default_tab_combo.currentIndex()
         if 0 <= idx < len(self._tab_display_names):
             self.settings['default_tab'] = self._tab_display_names[idx]
-        self.settings['experimental_features'] = self.experimental_check.isChecked()
+        if self.experimental_check.isVisible():
+            self.settings['experimental_features'] = self.experimental_check.isChecked()
 
         # Save disabled modules
         disabled_modules = []

--- a/core/settings_dialog.py
+++ b/core/settings_dialog.py
@@ -40,74 +40,67 @@ class SettingsDialog(QDialog):
         self.setMinimumWidth(600)
         self.setup_ui()
 
+    # ------------------------------------------------------------------
+    def _active(self, key: str) -> bool:
+        """Return True if this setting key is present in DEFAULT_SETTINGS."""
+        return self._active_keys is None or key in self._active_keys
+
+    def _dir_row(self, parent_layout, label_text: str, attr_name: str, setting_key: str):
+        """Add a label + line-edit + Browse row to parent_layout; hide if inactive."""
+        row = QWidget()
+        h = QHBoxLayout(row)
+        h.setContentsMargins(0, 2, 0, 2)
+        h.addWidget(QLabel(label_text))
+        edit = QLineEdit(self.settings.get(setting_key, ''))
+        setattr(self, attr_name, edit)
+        h.addWidget(edit, 1)
+        btn = QPushButton("Browse...")
+        btn.clicked.connect(lambda checked=False, e=edit: self.browse_dir(e))
+        h.addWidget(btn)
+        row.setVisible(self._active(setting_key))
+        parent_layout.addWidget(row)
+        return row
+
     def setup_ui(self):
-        # Main dialog layout
         main_layout = QVBoxLayout(self)
 
-        # Create scroll area for content
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll.setFrameShape(QFrame.Shape.NoFrame)
 
-        # Container for scrollable content
         scroll_widget = QWidget()
         scroll_layout = QVBoxLayout(scroll_widget)
 
-        # Directories group
+        # --- Directories ---
         dir_group = QGroupBox("Directories")
-        dir_layout = QGridLayout(dir_group)
-
-        # Blueprints
-        dir_layout.addWidget(QLabel("Blueprints Directory:"), 0, 0)
-        self.blueprints_edit = QLineEdit(self.settings.get('blueprints_dir', ''))
-        dir_layout.addWidget(self.blueprints_edit, 0, 1)
-        bp_btn = QPushButton("Browse...")
-        bp_btn.clicked.connect(lambda: self.browse_dir(self.blueprints_edit))
-        dir_layout.addWidget(bp_btn, 0, 2)
-
-        # Customer files
-        dir_layout.addWidget(QLabel("Customer Files Directory:"), 1, 0)
-        self.customer_files_edit = QLineEdit(self.settings.get('customer_files_dir', ''))
-        dir_layout.addWidget(self.customer_files_edit, 1, 1)
-        cf_btn = QPushButton("Browse...")
-        cf_btn.clicked.connect(lambda: self.browse_dir(self.customer_files_edit))
-        dir_layout.addWidget(cf_btn, 1, 2)
-
+        dir_vbox = QVBoxLayout(dir_group)
+        self._dir_row(dir_vbox, "Blueprints Directory:", 'blueprints_edit', 'blueprints_dir')
+        self._dir_row(dir_vbox, "Customer Files Directory:", 'customer_files_edit', 'customer_files_dir')
+        dir_group.setVisible(
+            self._active('blueprints_dir') or self._active('customer_files_dir')
+        )
         scroll_layout.addWidget(dir_group)
 
-        # ITAR directories group
+        # --- ITAR Directories ---
         itar_group = QGroupBox("ITAR Directories (optional)")
-        itar_layout = QGridLayout(itar_group)
-
-        itar_layout.addWidget(QLabel("ITAR Blueprints:"), 0, 0)
-        self.itar_blueprints_edit = QLineEdit(self.settings.get('itar_blueprints_dir', ''))
-        itar_layout.addWidget(self.itar_blueprints_edit, 0, 1)
-        itar_bp_btn = QPushButton("Browse...")
-        itar_bp_btn.clicked.connect(lambda: self.browse_dir(self.itar_blueprints_edit))
-        itar_layout.addWidget(itar_bp_btn, 0, 2)
-
-        itar_layout.addWidget(QLabel("ITAR Customer Files:"), 1, 0)
-        self.itar_customer_files_edit = QLineEdit(self.settings.get('itar_customer_files_dir', ''))
-        itar_layout.addWidget(self.itar_customer_files_edit, 1, 1)
-        itar_cf_btn = QPushButton("Browse...")
-        itar_cf_btn.clicked.connect(lambda: self.browse_dir(self.itar_customer_files_edit))
-        itar_layout.addWidget(itar_cf_btn, 1, 2)
-
+        itar_vbox = QVBoxLayout(itar_group)
+        self._dir_row(itar_vbox, "ITAR Blueprints:", 'itar_blueprints_edit', 'itar_blueprints_dir')
+        self._dir_row(itar_vbox, "ITAR Customer Files:", 'itar_customer_files_edit', 'itar_customer_files_dir')
+        itar_group.setVisible(
+            self._active('itar_blueprints_dir') or self._active('itar_customer_files_dir')
+        )
         scroll_layout.addWidget(itar_group)
 
-        # Link type group
+        # --- Link Type ---
         link_group = QGroupBox("Link Type")
         link_layout = QHBoxLayout(link_group)
-
         self.link_type_group = QButtonGroup(self)
         self.hard_radio = QRadioButton("Hard Link")
         self.symbolic_radio = QRadioButton("Symbolic Link")
         self.copy_radio = QRadioButton("Copy")
-
         self.link_type_group.addButton(self.hard_radio, 0)
         self.link_type_group.addButton(self.symbolic_radio, 1)
         self.link_type_group.addButton(self.copy_radio, 2)
-
         link_type = self.settings.get('link_type', 'hard')
         if link_type == 'hard':
             self.hard_radio.setChecked(True)
@@ -115,13 +108,10 @@ class SettingsDialog(QDialog):
             self.symbolic_radio.setChecked(True)
         else:
             self.copy_radio.setChecked(True)
-
         link_layout.addWidget(self.hard_radio)
         link_layout.addWidget(self.symbolic_radio)
         link_layout.addWidget(self.copy_radio)
         link_layout.addStretch()
-
-        # Add OS-specific tooltips
         if get_os_type() == "windows":
             self.hard_radio.setToolTip("Creates a hard link. Saves disk space. Files must be on same volume.")
             self.symbolic_radio.setToolTip("Creates a symbolic link. Requires admin or Developer Mode.")
@@ -130,41 +120,43 @@ class SettingsDialog(QDialog):
             self.hard_radio.setToolTip("Creates a hard link. Recommended - saves disk space.")
             self.symbolic_radio.setToolTip("Creates a symbolic link.")
             self.copy_radio.setToolTip("Creates an independent copy.")
-
+        link_group.setVisible(self._active('link_type'))
         scroll_layout.addWidget(link_group)
 
-        # Blueprint extensions
+        # --- Blueprint File Types ---
         ext_group = QGroupBox("Blueprint File Types")
         ext_layout = QVBoxLayout(ext_group)
-
         ext_layout.addWidget(QLabel("Files with these extensions go to blueprints folder:"))
         self.extensions_edit = QLineEdit(
             ', '.join(self.settings.get('blueprint_extensions', ['.pdf', '.dwg', '.dxf']))
         )
         ext_layout.addWidget(self.extensions_edit)
         ext_layout.addWidget(QLabel("(comma-separated, e.g., .pdf, .dwg, .dxf)"))
-
+        ext_group.setVisible(self._active('blueprint_extensions'))
         scroll_layout.addWidget(ext_group)
 
-        # Options
+        # --- Options ---
         options_group = QGroupBox("Options")
         options_layout = QVBoxLayout(options_group)
 
         self.allow_duplicates_check = QCheckBox("Allow duplicate job numbers (not recommended)")
         self.allow_duplicates_check.setChecked(self.settings.get('allow_duplicate_jobs', False))
+        self.allow_duplicates_check.setVisible(self._active('allow_duplicate_jobs'))
         options_layout.addWidget(self.allow_duplicates_check)
 
         self.skip_images_check = QCheckBox("Skip image attachments (.jpg, .png, etc.) when extracting emails")
         self.skip_images_check.setChecked(self.settings.get('skip_image_attachments', True))
         self.skip_images_check.setToolTip("Skips inline signature images when extracting email attachments.")
+        self.skip_images_check.setVisible(self._active('skip_image_attachments'))
         options_layout.addWidget(self.skip_images_check)
 
-        # Default tab setting — built from the actual enabled modules
-        default_tab_layout = QHBoxLayout()
-        default_tab_layout.addWidget(QLabel("Default opening tab:"))
+        default_tab_row = QWidget()
+        default_tab_h = QHBoxLayout(default_tab_row)
+        default_tab_h.setContentsMargins(0, 0, 0, 0)
+        default_tab_h.addWidget(QLabel("Default opening tab:"))
         self.default_tab_combo = QComboBox()
         disabled = self.settings.get('disabled_modules', [])
-        self._tab_display_names = []   # parallel list: display name for each combo item
+        self._tab_display_names = []
         for module_name, display_name in self.available_modules:
             if module_name not in disabled:
                 self.default_tab_combo.addItem(display_name)
@@ -176,33 +168,34 @@ class SettingsDialog(QDialog):
             current_default = self.settings.get('default_tab', '')
             if isinstance(current_default, str) and current_default in self._tab_display_names:
                 self.default_tab_combo.setCurrentIndex(self._tab_display_names.index(current_default))
-        default_tab_layout.addWidget(self.default_tab_combo)
-        default_tab_layout.addStretch()
-        options_layout.addLayout(default_tab_layout)
+        default_tab_h.addWidget(self.default_tab_combo)
+        default_tab_h.addStretch()
+        default_tab_row.setVisible(self._active('default_tab'))
+        options_layout.addWidget(default_tab_row)
 
+        options_group.setVisible(
+            self._active('allow_duplicate_jobs') or
+            self._active('skip_image_attachments') or
+            self._active('default_tab')
+        )
         scroll_layout.addWidget(options_group)
 
-        # Modules section
-        if self.available_modules:
+        # --- Modules ---
+        if self.available_modules and self._active('disabled_modules'):
             modules_group = QGroupBox("Modules")
             modules_layout = QVBoxLayout(modules_group)
-
             modules_layout.addWidget(QLabel("Enable or disable modules (requires restart):"))
-
             disabled_modules = self.settings.get('disabled_modules', [])
-
             for module_name, display_name in sorted(self.available_modules, key=lambda x: x[1]):
                 checkbox = QCheckBox(display_name)
                 checkbox.setChecked(module_name not in disabled_modules)
                 self.module_checkboxes[module_name] = checkbox
                 modules_layout.addWidget(checkbox)
-
             scroll_layout.addWidget(modules_group)
 
-        # Appearance
+        # --- Appearance ---
         appearance_group = QGroupBox("Appearance")
         appearance_layout = QGridLayout(appearance_group)
-
         appearance_layout.addWidget(QLabel("UI Style:"), 0, 0)
         self.style_combo = QComboBox()
         available_styles = QStyleFactory.keys()
@@ -212,13 +205,12 @@ class SettingsDialog(QDialog):
             self.style_combo.setCurrentText(current_style)
         appearance_layout.addWidget(self.style_combo, 0, 1)
         appearance_layout.addWidget(QLabel("(restart required)"), 0, 2)
-
+        appearance_group.setVisible(self._active('ui_style'))
         scroll_layout.addWidget(appearance_group)
 
-        # Remote Sync
+        # --- Remote Sync ---
         remote_group = QGroupBox("Remote Sync")
         remote_layout = QGridLayout(remote_group)
-
         remote_layout.addWidget(QLabel("Remote Server Path:"), 0, 0)
         self.remote_server_edit = QLineEdit(self.settings.get('remote_server_path', ''))
         self.remote_server_edit.setPlaceholderText(r"\\server\share\jobdocs or /mnt/share/jobdocs")
@@ -226,15 +218,14 @@ class SettingsDialog(QDialog):
         remote_browse_btn = QPushButton("Browse...")
         remote_browse_btn.clicked.connect(lambda: self.browse_dir(self.remote_server_edit))
         remote_layout.addWidget(remote_browse_btn, 0, 2)
-
         remote_info = QLabel("Settings and history will sync to/from remote server on startup/shutdown")
         remote_info.setWordWrap(True)
         remote_info.setStyleSheet("color: gray; font-size: 9pt;")
         remote_layout.addWidget(remote_info, 1, 0, 1, 3)
-
+        remote_group.setVisible(self._active('remote_server_path'))
         scroll_layout.addWidget(remote_group)
 
-        # Advanced Settings (collapsible)
+        # --- Advanced Settings (collapsible) ---
         self.advanced_group = QGroupBox("Advanced Settings")
         self.advanced_group.setCheckable(True)
         self.advanced_group.setChecked(False)
@@ -248,49 +239,53 @@ class SettingsDialog(QDialog):
         path_sep = get_os_text('path_sep')
         legacy_example = f"{{customer}}{path_sep}job documents{path_sep}{{job_folder}}"
 
-        advanced_content_layout.addWidget(QLabel("Job Folder Structure:"))
-        advanced_content_layout.addWidget(QLabel("Available placeholders: {customer}, {job_folder}, {po_number}"))
-        advanced_content_layout.addWidget(QLabel(f"Default: {path_example}"))
-        advanced_content_layout.addWidget(QLabel(f"Legacy: {legacy_example}"))
-
+        _job_struct_block = QWidget()
+        _js_vbox = QVBoxLayout(_job_struct_block)
+        _js_vbox.setContentsMargins(0, 0, 0, 0)
+        _js_vbox.addWidget(QLabel("Job Folder Structure:"))
+        _js_vbox.addWidget(QLabel("Available placeholders: {customer}, {job_folder}, {po_number}"))
+        _js_vbox.addWidget(QLabel(f"Default: {path_example}"))
+        _js_vbox.addWidget(QLabel(f"Legacy: {legacy_example}"))
         self.job_structure_edit = QLineEdit(
             self.settings.get('job_folder_structure', '{customer}/{job_folder}/job documents')
         )
-        advanced_content_layout.addWidget(self.job_structure_edit)
+        _js_vbox.addWidget(self.job_structure_edit)
+        _job_struct_block.setVisible(self._active('job_folder_structure'))
+        advanced_content_layout.addWidget(_job_struct_block)
 
-        _quote_label = QLabel("Quote Folder Path:")
+        _quote_block = QWidget()
+        _q_vbox = QVBoxLayout(_quote_block)
+        _q_vbox.setContentsMargins(0, 0, 0, 0)
+        _q_vbox.addWidget(QLabel("Quote Folder Path:"))
         self.quote_folder_edit = QLineEdit(self.settings.get('quote_folder_path', 'Quotes'))
-        _quote_visible = self._active_keys is None or 'quote_folder_path' in self._active_keys
-        _quote_label.setVisible(_quote_visible)
-        self.quote_folder_edit.setVisible(_quote_visible)
-        advanced_content_layout.addWidget(_quote_label)
-        advanced_content_layout.addWidget(self.quote_folder_edit)
-
-        advanced_content_layout.addWidget(QLabel(""))
+        _q_vbox.addWidget(self.quote_folder_edit)
+        _quote_block.setVisible(self._active('quote_folder_path'))
+        advanced_content_layout.addWidget(_quote_block)
 
         self.legacy_mode_check = QCheckBox("Enable legacy mode (shows 'Search All Folders' option)")
         self.legacy_mode_check.setChecked(self.settings.get('legacy_mode', True))
+        self.legacy_mode_check.setVisible(self._active('legacy_mode'))
         advanced_content_layout.addWidget(self.legacy_mode_check)
 
         self.experimental_check = QCheckBox("Enable experimental features (Reporting)")
         self.experimental_check.setChecked(self.settings.get('experimental_features', False))
         self.experimental_check.setToolTip("Enables experimental features. Requires restart.")
-        _exp_visible = self._active_keys is None or 'experimental_features' in self._active_keys
-        self.experimental_check.setVisible(_exp_visible)
+        self.experimental_check.setVisible(self._active('experimental_features'))
         advanced_content_layout.addWidget(self.experimental_check)
 
         advanced_layout.addWidget(self.advanced_content)
-
         self.advanced_content.setVisible(False)
         self.advanced_group.toggled.connect(self.advanced_content.setVisible)
 
+        _any_advanced = any(self._active(k) for k in (
+            'job_folder_structure', 'quote_folder_path', 'legacy_mode', 'experimental_features'
+        ))
+        self.advanced_group.setVisible(_any_advanced)
         scroll_layout.addWidget(self.advanced_group)
 
-        # Set scroll widget and add to main layout
         scroll.setWidget(scroll_widget)
         main_layout.addWidget(scroll)
 
-        # Buttons
         button_box = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Save | QDialogButtonBox.StandardButton.Cancel
         )
@@ -304,43 +299,53 @@ class SettingsDialog(QDialog):
             line_edit.setText(dir_path)
 
     def save(self):
-        self.settings['blueprints_dir'] = self.blueprints_edit.text()
-        self.settings['customer_files_dir'] = self.customer_files_edit.text()
-        self.settings['itar_blueprints_dir'] = self.itar_blueprints_edit.text()
-        self.settings['itar_customer_files_dir'] = self.itar_customer_files_edit.text()
+        if self._active('blueprints_dir'):
+            self.settings['blueprints_dir'] = self.blueprints_edit.text()
+        if self._active('customer_files_dir'):
+            self.settings['customer_files_dir'] = self.customer_files_edit.text()
+        if self._active('itar_blueprints_dir'):
+            self.settings['itar_blueprints_dir'] = self.itar_blueprints_edit.text()
+        if self._active('itar_customer_files_dir'):
+            self.settings['itar_customer_files_dir'] = self.itar_customer_files_edit.text()
 
-        if self.hard_radio.isChecked():
-            self.settings['link_type'] = 'hard'
-        elif self.symbolic_radio.isChecked():
-            self.settings['link_type'] = 'symbolic'
-        else:
-            self.settings['link_type'] = 'copy'
+        if self._active('link_type'):
+            if self.hard_radio.isChecked():
+                self.settings['link_type'] = 'hard'
+            elif self.symbolic_radio.isChecked():
+                self.settings['link_type'] = 'symbolic'
+            else:
+                self.settings['link_type'] = 'copy'
 
-        extensions = [ext.strip().lower() for ext in self.extensions_edit.text().split(',') if ext.strip()]
-        extensions = [ext if ext.startswith('.') else f'.{ext}' for ext in extensions]
-        self.settings['blueprint_extensions'] = extensions
+        if self._active('blueprint_extensions'):
+            extensions = [ext.strip().lower() for ext in self.extensions_edit.text().split(',') if ext.strip()]
+            extensions = [ext if ext.startswith('.') else f'.{ext}' for ext in extensions]
+            self.settings['blueprint_extensions'] = extensions
 
-        self.settings['job_folder_structure'] = self.job_structure_edit.text().strip()
-        if self.quote_folder_edit.isVisible():
+        if self._active('job_folder_structure'):
+            self.settings['job_folder_structure'] = self.job_structure_edit.text().strip()
+        if self._active('quote_folder_path'):
             self.settings['quote_folder_path'] = self.quote_folder_edit.text().strip()
-        self.settings['legacy_mode'] = self.legacy_mode_check.isChecked()
-        self.settings['allow_duplicate_jobs'] = self.allow_duplicates_check.isChecked()
-        self.settings['skip_image_attachments'] = self.skip_images_check.isChecked()
-        self.settings['ui_style'] = self.style_combo.currentText()
-        idx = self.default_tab_combo.currentIndex()
-        if 0 <= idx < len(self._tab_display_names):
-            self.settings['default_tab'] = self._tab_display_names[idx]
-        if self.experimental_check.isVisible():
+        if self._active('legacy_mode'):
+            self.settings['legacy_mode'] = self.legacy_mode_check.isChecked()
+        if self._active('allow_duplicate_jobs'):
+            self.settings['allow_duplicate_jobs'] = self.allow_duplicates_check.isChecked()
+        if self._active('skip_image_attachments'):
+            self.settings['skip_image_attachments'] = self.skip_images_check.isChecked()
+        if self._active('ui_style'):
+            self.settings['ui_style'] = self.style_combo.currentText()
+        if self._active('default_tab'):
+            idx = self.default_tab_combo.currentIndex()
+            if 0 <= idx < len(self._tab_display_names):
+                self.settings['default_tab'] = self._tab_display_names[idx]
+        if self._active('experimental_features'):
             self.settings['experimental_features'] = self.experimental_check.isChecked()
-
-        # Save disabled modules
-        disabled_modules = []
-        for module_name, checkbox in self.module_checkboxes.items():
-            if not checkbox.isChecked():
-                disabled_modules.append(module_name)
-        self.settings['disabled_modules'] = disabled_modules
-
-        # Save remote server path
-        self.settings['remote_server_path'] = self.remote_server_edit.text().strip()
+        if self._active('disabled_modules'):
+            disabled_modules = []
+            for module_name, checkbox in self.module_checkboxes.items():
+                if not checkbox.isChecked():
+                    disabled_modules.append(module_name)
+            self.settings['disabled_modules'] = disabled_modules
+        if self._active('remote_server_path'):
+            self.settings['remote_server_path'] = self.remote_server_edit.text().strip()
 
         self.accept()

--- a/core/settings_dialog.py
+++ b/core/settings_dialog.py
@@ -38,6 +38,7 @@ class SettingsDialog(QDialog):
         self._save_callback = save_callback  # Called to persist settings to disk mid-dialog
         self.setWindowTitle("Settings")
         self.setMinimumWidth(600)
+        self.resize(630, 500)
         self.setup_ui()
 
     # ------------------------------------------------------------------

--- a/main.py
+++ b/main.py
@@ -195,8 +195,7 @@ class _PluginInstallWorker(QThread):
 
 
 class JobDocsMainWindow(QMainWindow):
-    """Main application window with modular plugin system
-    comment out to remove from settings"""
+    """Main application window with modular plugin system"""
 
     DEFAULT_SETTINGS = {
         'blueprints_dir': '',
@@ -222,7 +221,7 @@ class JobDocsMainWindow(QMainWindow):
 #        'remote_server_path': '',  # Network path or URL for remote settings sync
         'report_template_path': '',  # Path to Excel template for Report Fixer
         'suppress_bp_link_notification': False,  # Suppress "linked to blueprints" confirmation dialog
-        'skip_image_attachments': False,
+        'skip_image_attachments': True,
     }
 
     def __init__(self):

--- a/main.py
+++ b/main.py
@@ -195,7 +195,8 @@ class _PluginInstallWorker(QThread):
 
 
 class JobDocsMainWindow(QMainWindow):
-    """Main application window with modular plugin system"""
+    """Main application window with modular plugin system
+    comment out to remove from settings"""
 
     DEFAULT_SETTINGS = {
         'blueprints_dir': '',
@@ -210,18 +211,18 @@ class JobDocsMainWindow(QMainWindow):
         'quote_folder_path': 'Quotes',
         'legacy_mode': True,
         'default_tab': 0,
-        'experimental_features': False,
+#        'experimental_features': False,
         'disabled_modules': [],  # List of disabled module names
         'db_type': 'mssql',
-        'db_host': 'localhost',
-        'db_port': 1433,
-        'db_name': '',
-        'db_username': '',
-        'db_password': '',
+#        'db_host': 'localhost',
+#        'db_port': 1433,
+#        'db_name': '',
+#        'db_username': '',
+#        'db_password': '',
         'remote_server_path': '',  # Network path or URL for remote settings sync
         'report_template_path': '',  # Path to Excel template for Report Fixer
         'suppress_bp_link_notification': False,  # Suppress "linked to blueprints" confirmation dialog
-        'skip_image_attachments': True,
+        'skip_image_attachments': False,
     }
 
     def __init__(self):
@@ -544,7 +545,8 @@ class JobDocsMainWindow(QMainWindow):
                 available_modules.append((module_name, module_name))
 
         dialog = SettingsDialog(self.settings, self, available_modules,
-                               save_callback=self._partial_save_settings)
+                               save_callback=self._partial_save_settings,
+                               active_keys=set(self.DEFAULT_SETTINGS))
         if dialog.exec() == QDialog.DialogCode.Accepted:
             self.settings = dialog.settings
 

--- a/main.py
+++ b/main.py
@@ -208,18 +208,18 @@ class JobDocsMainWindow(QMainWindow):
         'allow_duplicate_jobs': False,
         'ui_style': 'Fusion',
         'job_folder_structure': '{customer}/job documents/{job_folder}',
-        'quote_folder_path': 'Quotes',
+#        'quote_folder_path': 'Quotes',
         'legacy_mode': True,
         'default_tab': 0,
 #        'experimental_features': False,
         'disabled_modules': [],  # List of disabled module names
-        'db_type': 'mssql',
+#        'db_type': 'mssql',
 #        'db_host': 'localhost',
 #        'db_port': 1433,
 #        'db_name': '',
 #        'db_username': '',
 #        'db_password': '',
-        'remote_server_path': '',  # Network path or URL for remote settings sync
+#        'remote_server_path': '',  # Network path or URL for remote settings sync
         'report_template_path': '',  # Path to Excel template for Report Fixer
         'suppress_bp_link_notification': False,  # Suppress "linked to blueprints" confirmation dialog
         'skip_image_attachments': False,

--- a/modules/job/module.py
+++ b/modules/job/module.py
@@ -523,7 +523,15 @@ class JobModule(BaseModule):
 
     def auto_generate_job_number(self):
         """Auto-generate the next job number"""
-        next_number = get_next_number(self.app_context.history, 'job', start_number=10000)
+        scan_dirs = [
+            self.app_context.get_setting('customer_files_dir', ''),
+            self.app_context.get_setting('itar_customer_files_dir', ''),
+            self.app_context.get_setting('blueprints_dir', ''),
+            self.app_context.get_setting('itar_blueprints_dir', ''),
+        ]
+        next_number = get_next_number(
+            self.app_context.history, 'job', start_number=10000, scan_dirs=scan_dirs
+        )
         self.job_number_edit.setText(next_number)
         self.log_message(f"Auto-generated job number: {next_number}")
 

--- a/modules/quote/module.py
+++ b/modules/quote/module.py
@@ -493,7 +493,8 @@ class QuoteModule(BaseModule):
             self.app_context.get_setting('itar_customer_files_dir', ''),
         ]
         next_number = get_next_number(
-            self.app_context.history, 'quote', start_number=90000, scan_dirs=scan_dirs
+            self.app_context.history, 'quote', start_number=90000, scan_dirs=scan_dirs,
+            quote_folder=self.app_context.get_setting('quote_folder_path', 'Quotes'),
         )
         quote_number = f"Q{next_number}"
         self.quote_number_edit.setText(quote_number)

--- a/modules/quote/module.py
+++ b/modules/quote/module.py
@@ -488,7 +488,13 @@ class QuoteModule(BaseModule):
 
     def auto_generate_quote_number(self):
         """Auto-generate the next quote number"""
-        next_number = get_next_number(self.app_context.history, 'quote', start_number=90000)
+        scan_dirs = [
+            self.app_context.get_setting('customer_files_dir', ''),
+            self.app_context.get_setting('itar_customer_files_dir', ''),
+        ]
+        next_number = get_next_number(
+            self.app_context.history, 'quote', start_number=90000, scan_dirs=scan_dirs
+        )
         quote_number = f"Q{next_number}"
         self.quote_number_edit.setText(quote_number)
         self.log_message(f"Auto-generated quote number: {quote_number}")

--- a/shared/utils.py
+++ b/shared/utils.py
@@ -221,7 +221,7 @@ def print_files(paths: List[str]) -> None:
 
 
 def get_next_number(history: Dict[str, Any], entry_type: str, start_number: int = 10000,
-                    scan_dirs: list | None = None) -> str:
+                    scan_dirs: list | None = None, quote_folder: str = 'Quotes') -> str:
     """
     Get the next sequential number for jobs or quotes.
 
@@ -232,9 +232,10 @@ def get_next_number(history: Dict[str, Any], entry_type: str, start_number: int 
                scanned for leading numbers (e.g. customer-files and blueprints
                dirs).  Two levels are walked: base→customer→folder so that
                quote folders nested inside a Quotes sub-directory are found.
+    quote_folder: name of the quotes sub-directory (matches quote_folder_path
+                  setting, defaults to 'Quotes').
     """
-    import re as _re
-    _leading_num = _re.compile(r'^[A-Za-z]?(\d+)')
+    _leading_num = re.compile(r'^[A-Za-z]?(\d+)')
 
     max_number = start_number - 1
 
@@ -260,10 +261,8 @@ def get_next_number(history: Dict[str, Any], entry_type: str, start_number: int 
             continue
 
     # --- file system ---
-    # Jobs live at base/customer/<job_folder>; skip the Quotes sub-directory.
-    # Quotes live at base/customer/Quotes/<quote_folder>.
-    _QUOTES_DIR = 'Quotes'
-
+    # Jobs live at base/customer/<job_folder>; skip the quotes sub-directory.
+    # Quotes live at base/customer/<quote_folder>/<quote_folder_entry>.
     if scan_dirs:
         def _check(name: str) -> None:
             nonlocal max_number
@@ -283,13 +282,13 @@ def get_next_number(history: Dict[str, Any], entry_type: str, start_number: int 
                         continue
                     try:
                         if entry_type == 'quote':
-                            quotes_path = os.path.join(customer_path, _QUOTES_DIR)
+                            quotes_path = os.path.join(customer_path, quote_folder)
                             if os.path.isdir(quotes_path):
                                 for name in os.listdir(quotes_path):
                                     _check(name)
                         else:
                             for name in os.listdir(customer_path):
-                                if name.lower() != _QUOTES_DIR.lower():
+                                if name.lower() != quote_folder.lower():
                                     _check(name)
                     except OSError:
                         continue

--- a/shared/utils.py
+++ b/shared/utils.py
@@ -220,21 +220,24 @@ def print_files(paths: List[str]) -> None:
                 logger.warning("print_files: 'lp' not found — cannot print %s", path)
 
 
-def get_next_number(history: Dict[str, Any], entry_type: str, start_number: int = 10000) -> str:
+def get_next_number(history: Dict[str, Any], entry_type: str, start_number: int = 10000,
+                    scan_dirs: list | None = None) -> str:
     """
-    Get the next sequential number for jobs or quotes (tracked separately).
+    Get the next sequential number for jobs or quotes.
 
-    Args:
-        history: Application history dictionary
-        entry_type: Type of entry ('job' or 'quote')
-        start_number: Starting number if no history exists (default: 10000)
+    Checks both the in-memory history and (optionally) the file system so that
+    folders created outside of JobDocs are not re-used.
 
-    Returns:
-        Next number as a string
+    scan_dirs: list of base directories whose immediate subdirectory names are
+               scanned for leading numbers (e.g. customer-files and blueprints
+               dirs).  Two levels are walked: base→customer→folder so that
+               quote folders nested inside a Quotes sub-directory are found.
     """
+    import re as _re
+    _leading_num = _re.compile(r'^[A-Za-z]?(\d+)')
+
     max_number = start_number - 1
 
-    # Determine which history key to use (jobs and quotes are tracked separately)
     if entry_type == 'job':
         history_key = 'recent_jobs'
         number_key = 'job_number'
@@ -244,20 +247,53 @@ def get_next_number(history: Dict[str, Any], entry_type: str, start_number: int 
     else:
         return str(start_number)
 
-    # Check history for the highest number
-    recent_entries = history.get(history_key, [])
-    for entry in recent_entries:
+    # --- history ---
+    for entry in history.get(history_key, []):
         number_str = entry.get(number_key, '')
-        # Try to parse as integer, stripping any leading non-digits (like 'Q' prefix)
         try:
-            # Extract only digits from the string
             digits = ''.join(filter(str.isdigit, number_str))
             if digits:
-                number = int(digits)
-                if number > max_number:
-                    max_number = number
+                n = int(digits)
+                if n > max_number:
+                    max_number = n
         except (ValueError, TypeError):
-            # Not parseable, skip it
             continue
+
+    # --- file system ---
+    # Jobs live at base/customer/<job_folder>; skip the Quotes sub-directory.
+    # Quotes live at base/customer/Quotes/<quote_folder>.
+    _QUOTES_DIR = 'Quotes'
+
+    if scan_dirs:
+        def _check(name: str) -> None:
+            nonlocal max_number
+            m = _leading_num.match(name)
+            if m:
+                n = int(m.group(1))
+                if n > max_number:
+                    max_number = n
+
+        for base_dir in scan_dirs:
+            if not base_dir or not os.path.isdir(base_dir):
+                continue
+            try:
+                for customer in os.listdir(base_dir):
+                    customer_path = os.path.join(base_dir, customer)
+                    if not os.path.isdir(customer_path):
+                        continue
+                    try:
+                        if entry_type == 'quote':
+                            quotes_path = os.path.join(customer_path, _QUOTES_DIR)
+                            if os.path.isdir(quotes_path):
+                                for name in os.listdir(quotes_path):
+                                    _check(name)
+                        else:
+                            for name in os.listdir(customer_path):
+                                if name.lower() != _QUOTES_DIR.lower():
+                                    _check(name)
+                    except OSError:
+                        continue
+            except OSError:
+                continue
 
     return str(max_number + 1)

--- a/shared/widgets.py
+++ b/shared/widgets.py
@@ -1599,16 +1599,14 @@ def print_files_with_dialog(paths: list, parent=None, app_context=None) -> None:
                     _hooked = True
                     break
             if not _hooked:
-                # Could not find the toolbar Print action — show the preview
-                # anyway. The default QPrintPreviewDialog print button will
-                # print to the PDF preview printer at 96 DPI rather than the
-                # high-res path, but it still works.
                 logger.warning(
                     "print_files_with_dialog: could not locate Print toolbar "
-                    "action in QPrintPreviewDialog; using default print path."
+                    "action in QPrintPreviewDialog; printing directly at high resolution."
                 )
-            if preview.exec() != QPrintPreviewDialog.DialogCode.Accepted:
-                cancelled = True
+                _do_print()
+            else:
+                if preview.exec() != QPrintPreviewDialog.DialogCode.Accepted:
+                    cancelled = True
 
     if cancelled:
         return


### PR DESCRIPTION
## Summary
- `get_next_number()` previously only checked in-memory history, so it would re-use numbers that existed on disk but not in history (legacy folders, folders created outside JobDocs, etc.)
- Now accepts `scan_dirs` and walks the file system: jobs scan `base/customer/<folder>` (skipping the `Quotes` sub-directory), quotes scan `base/customer/Quotes/<folder>`
- Job module passes CF, ITAR-CF, BP, and ITAR-BP dirs; quote module passes CF and ITAR-CF dirs

## Test plan
- [ ] Auto-generate a job number with existing job folders on disk — should return max+1, not a duplicate
- [ ] Auto-generate a quote number with existing quote folders in `Quotes/` — should return max+1
- [ ] Verify job scan does not pick up quote numbers from `Quotes/` sub-directory
- [ ] Verify behaviour when no dirs are configured (scan_dirs all empty) — falls back to history only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced print preview dialog with improved action detection and automatic sizing.

* **Improvements**
  * Refined search results panel layout for better content visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->