### PR TITLE
feat: automated weekly code audit posts findings as GitHub issues

### DIFF
--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -2007,3 +2007,11 @@ Actionable: 2  Nitpicks: 2
 - Clarify the version computation step in the example.
 - Specify the expected action when checking thresholds.
 - Configuration used
+
+---
+
+## 2026-04-18 — `PR #35: feat: automated weekly code audit posts findings as GitHub issues` — run 1
+
+Actionable: 3  Nitpicks: 1
+- Consider a summary-issue mode to avoid issue-tracker noise.
+- Configuration used

--- a/.github/workflows/code-audit.yml
+++ b/.github/workflows/code-audit.yml
@@ -1,0 +1,48 @@
+name: Automated Code Audit
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'   # Every Monday at 06:00 UTC
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install audit tools
+        run: pip install flake8 bandit
+
+      - name: Run flake8 (errors and undefined names only)
+        run: |
+          flake8 \
+            --max-line-length=120 \
+            --select=E,F \
+            --exclude=.git,__pycache__,build_scripts,linux \
+            . > flake8_results.txt 2>&1 || true
+
+      - name: Run bandit (medium/high severity only)
+        run: |
+          bandit -r . \
+            --exclude ./.git,./build_scripts,./linux \
+            --severity-level medium \
+            -f json -o bandit_results.json -q || true
+
+      - name: Post findings as GitHub issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python build_scripts/post_audit_issues.py

--- a/build_scripts/post_audit_issues.py
+++ b/build_scripts/post_audit_issues.py
@@ -22,31 +22,19 @@ def _fetch_existing_titles() -> set:
     if _existing_titles is not None:
         return _existing_titles
 
-    # Paginate: gh issue list max is 1000 per call; loop until exhausted.
-    titles: set = set()
-    skip = 0
-    page_size = 100
-    while True:
-        result = subprocess.run(
-            ['gh', 'issue', 'list',
-             '--label', LABEL,
-             '--state', 'open',
-             '--json', 'title',
-             '--limit', str(page_size),
-             '--skip', str(skip)],
-            capture_output=True, text=True,
-        )
-        if result.returncode != 0:
-            print(f'ERROR: could not fetch existing issues: {result.stderr}', file=sys.stderr)
-            sys.exit(1)
-        page = json.loads(result.stdout or '[]')
-        for i in page:
-            titles.add(i['title'])
-        if len(page) < page_size:
-            break
-        skip += page_size
+    result = subprocess.run(
+        ['gh', 'issue', 'list',
+         '--label', LABEL,
+         '--state', 'open',
+         '--json', 'title',
+         '--limit', '1000'],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(f'ERROR: could not fetch existing issues: {result.stderr}', file=sys.stderr)
+        sys.exit(1)
 
-    _existing_titles = titles
+    _existing_titles = {i['title'] for i in json.loads(result.stdout or '[]')}
     return _existing_titles
 
 

--- a/build_scripts/post_audit_issues.py
+++ b/build_scripts/post_audit_issues.py
@@ -5,6 +5,7 @@ Parse flake8 and bandit output and create GitHub issues for new findings.
 Deduplicates against existing open issues tagged 'automated-audit' so
 re-running the workflow never creates duplicate issues.
 """
+import hashlib
 import json
 import os
 import re
@@ -16,33 +17,66 @@ _existing_titles: set | None = None
 
 
 def _fetch_existing_titles() -> set:
+    """Fetch titles of all open automated-audit issues. Aborts on failure."""
     global _existing_titles
     if _existing_titles is not None:
         return _existing_titles
-    result = subprocess.run(
-        ['gh', 'issue', 'list',
-         '--label', LABEL,
-         '--state', 'open',
-         '--json', 'title',
-         '--limit', '500'],
-        capture_output=True, text=True,
-    )
-    if result.returncode != 0:
-        print(f'WARNING: could not fetch existing issues: {result.stderr}', file=sys.stderr)
-        _existing_titles = set()
-    else:
-        _existing_titles = {i['title'] for i in json.loads(result.stdout or '[]')}
+
+    # Paginate: gh issue list max is 1000 per call; loop until exhausted.
+    titles: set = set()
+    skip = 0
+    page_size = 100
+    while True:
+        result = subprocess.run(
+            ['gh', 'issue', 'list',
+             '--label', LABEL,
+             '--state', 'open',
+             '--json', 'title',
+             '--limit', str(page_size),
+             '--skip', str(skip)],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            print(f'ERROR: could not fetch existing issues: {result.stderr}', file=sys.stderr)
+            sys.exit(1)
+        page = json.loads(result.stdout or '[]')
+        for i in page:
+            titles.add(i['title'])
+        if len(page) < page_size:
+            break
+        skip += page_size
+
+    _existing_titles = titles
     return _existing_titles
 
 
 def _ensure_label() -> None:
-    subprocess.run(
-        ['gh', 'label', 'create', LABEL,
-         '--color', 'e4e669',
-         '--description', 'Opened automatically by the weekly code audit',
-         '--force'],
-        capture_output=True,
-    )
+    """Create all labels used by this script idempotently."""
+    labels = [
+        (LABEL,      'e4e669', 'Opened automatically by the weekly code audit'),
+        ('bug',      'd73a4a', 'Something is not working'),
+        ('security', 'e11d48', 'Security vulnerability or concern'),
+    ]
+    for name, color, desc in labels:
+        subprocess.run(
+            ['gh', 'label', 'create', name,
+             '--color', color,
+             '--description', desc,
+             '--force'],
+            capture_output=True,
+        )
+
+
+def _fingerprint(tool: str, code: str, filepath: str, lineno: str | int, msg: str) -> str:
+    """Short deterministic hash that survives message truncation."""
+    key = f'{tool}:{code}:{filepath}:{lineno}:{msg}'
+    return hashlib.sha1(key.encode()).hexdigest()[:8]
+
+
+def _make_title(tool: str, code: str, msg: str, fname: str, lineno: str | int,
+                fp: str) -> str:
+    snippet = msg[:72]
+    return f'[Audit] {tool} {code}: {snippet} in {fname}:{lineno} [{fp}]'
 
 
 def _create_issue(title: str, body: str, extra_label: str) -> None:
@@ -80,7 +114,8 @@ def _parse_flake8(path: str) -> list:
                 continue
             filepath, lineno, col, code, msg = m.groups()
             fname = os.path.basename(filepath)
-            title = f'[Audit] flake8 {code}: {msg[:80]} in {fname}:{lineno}'
+            fp = _fingerprint('flake8', code, filepath, lineno, msg)
+            title = _make_title('flake8', code, msg, fname, lineno, fp)
             body = (
                 f'**Tool:** flake8  \n'
                 f'**File:** `{filepath}:{lineno}:{col}`  \n'
@@ -115,7 +150,8 @@ def _parse_bandit(path: str) -> list:
         filepath = result.get('filename', '')
         lineno = result.get('line_number', 0)
         fname = os.path.basename(filepath)
-        title = f'[Audit] bandit {test_id}: {msg[:80]} in {fname}:{lineno}'
+        fp = _fingerprint('bandit', test_id, filepath, lineno, msg)
+        title = _make_title('bandit', test_id, msg, fname, lineno, fp)
         body = (
             f'**Tool:** bandit  \n'
             f'**File:** `{filepath}:{lineno}`  \n'

--- a/build_scripts/post_audit_issues.py
+++ b/build_scripts/post_audit_issues.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+Parse flake8 and bandit output and create GitHub issues for new findings.
+
+Deduplicates against existing open issues tagged 'automated-audit' so
+re-running the workflow never creates duplicate issues.
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+
+LABEL = 'automated-audit'
+_existing_titles: set | None = None
+
+
+def _fetch_existing_titles() -> set:
+    global _existing_titles
+    if _existing_titles is not None:
+        return _existing_titles
+    result = subprocess.run(
+        ['gh', 'issue', 'list',
+         '--label', LABEL,
+         '--state', 'open',
+         '--json', 'title',
+         '--limit', '500'],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(f'WARNING: could not fetch existing issues: {result.stderr}', file=sys.stderr)
+        _existing_titles = set()
+    else:
+        _existing_titles = {i['title'] for i in json.loads(result.stdout or '[]')}
+    return _existing_titles
+
+
+def _ensure_label() -> None:
+    subprocess.run(
+        ['gh', 'label', 'create', LABEL,
+         '--color', 'e4e669',
+         '--description', 'Opened automatically by the weekly code audit',
+         '--force'],
+        capture_output=True,
+    )
+
+
+def _create_issue(title: str, body: str, extra_label: str) -> None:
+    existing = _fetch_existing_titles()
+    if title in existing:
+        print(f'  skip (exists): {title[:100]}')
+        return
+    result = subprocess.run(
+        ['gh', 'issue', 'create',
+         '--title', title,
+         '--body', body,
+         '--label', LABEL,
+         '--label', extra_label],
+        capture_output=True, text=True,
+    )
+    if result.returncode == 0:
+        existing.add(title)
+        print(f'  created: {title[:100]}')
+    else:
+        print(f'  error: {result.stderr[:200]}', file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# flake8
+# ---------------------------------------------------------------------------
+def _parse_flake8(path: str) -> list:
+    findings = []
+    if not os.path.exists(path):
+        return findings
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            m = re.match(r'^(.+?):(\d+):(\d+): ([EF]\d+) (.+)$', line)
+            if not m:
+                continue
+            filepath, lineno, col, code, msg = m.groups()
+            fname = os.path.basename(filepath)
+            title = f'[Audit] flake8 {code}: {msg[:80]} in {fname}:{lineno}'
+            body = (
+                f'**Tool:** flake8  \n'
+                f'**File:** `{filepath}:{lineno}:{col}`  \n'
+                f'**Code:** `{code}`  \n'
+                f'**Message:** {msg}\n\n'
+                f'---\n'
+                f'*Opened automatically by the weekly code audit. '
+                f'Close this issue once the finding is resolved or accepted.*'
+            )
+            findings.append((title, body, 'bug'))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# bandit
+# ---------------------------------------------------------------------------
+def _parse_bandit(path: str) -> list:
+    findings = []
+    if not os.path.exists(path):
+        return findings
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+    except (json.JSONDecodeError, OSError):
+        return findings
+    for result in data.get('results', []):
+        test_id = result.get('test_id', '')
+        test_name = result.get('test_name', '')
+        msg = result.get('issue_text', '')
+        severity = result.get('issue_severity', 'LOW')
+        confidence = result.get('issue_confidence', 'LOW')
+        filepath = result.get('filename', '')
+        lineno = result.get('line_number', 0)
+        fname = os.path.basename(filepath)
+        title = f'[Audit] bandit {test_id}: {msg[:80]} in {fname}:{lineno}'
+        body = (
+            f'**Tool:** bandit  \n'
+            f'**File:** `{filepath}:{lineno}`  \n'
+            f'**Test:** `{test_id}` — {test_name}  \n'
+            f'**Severity:** {severity} | **Confidence:** {confidence}  \n'
+            f'**Message:** {msg}\n\n'
+            f'---\n'
+            f'*Opened automatically by the weekly code audit. '
+            f'Close this issue once the finding is resolved or accepted.*'
+        )
+        findings.append((title, body, 'security'))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+def main() -> None:
+    _ensure_label()
+
+    findings: list = []
+    findings += _parse_flake8('flake8_results.txt')
+    findings += _parse_bandit('bandit_results.json')
+
+    print(f'Audit complete: {len(findings)} finding(s)')
+
+    for title, body, extra_label in findings:
+        _create_issue(title, body, extra_label)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/code-audit.yml` — runs every Monday at 06:00 UTC (and on manual dispatch)
- Runs **flake8** (errors + undefined names, E/F codes only) and **bandit** (medium/high severity only)
- `build_scripts/post_audit_issues.py` parses results and opens a GitHub issue per finding
- Deduplicates: checks existing open `automated-audit` issues before creating — re-running never duplicates
- Issues are labelled `automated-audit` + `bug` (flake8) or `security` (bandit)

## Test plan
- [ ] Trigger manually via Actions → Automated Code Audit → Run workflow
- [ ] Verify issues appear in the Issues tab labelled `automated-audit`
- [ ] Run again — verify no duplicate issues are created
- [ ] Close an issue, run again — verify it re-opens for the same finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated code audits now execute weekly on Mondays and on-demand with manual trigger.
  * Audit findings are automatically posted as GitHub issues with deduplication to prevent duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->