### PR TITLE
fix: resolve flake8/bandit audit findings in widgets.py and tests

### DIFF
--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -2015,3 +2015,11 @@ Actionable: 2  Nitpicks: 2
 Actionable: 3  Nitpicks: 1
 - Consider a summary-issue mode to avoid issue-tracker noise.
 - Configuration used
+
+---
+
+## 2026-04-19 — `PR #160: fix: resolve flake8/bandit audit findings in widgets.py and tests` — run 1
+
+Actionable: ?  Nitpicks: 1
+- Consider using `frozenset` for consistency.
+- Configuration used

--- a/shared/widgets.py
+++ b/shared/widgets.py
@@ -7,7 +7,7 @@ Common UI widgets used across multiple modules.
 from PyQt6.QtWidgets import (
     QFrame, QDialog, QVBoxLayout, QScrollArea, QLabel, QDialogButtonBox,
     QPushButton, QFileDialog, QLineEdit, QListWidget, QHBoxLayout,
-    QTreeWidget, QTreeWidgetItem, QCheckBox, QHeaderView,
+    QTreeWidget, QTreeWidgetItem, QHeaderView,
     QWidget, QSplitter, QSizePolicy
 )
 from PyQt6.QtCore import Qt, pyqtSignal, QSize
@@ -548,7 +548,7 @@ class DropZone(QFrame):
         try:
             plain_bytes = bytes(mime_data.data('text/plain'))
             plain = plain_bytes.decode('utf-8', errors='replace')
-            lines = [l for l in plain.splitlines() if l.strip()]
+            lines = [ln for ln in plain.splitlines() if ln.strip()]
             for line in lines:
                 cols = line.split('\t')
                 if cols[0].strip().lower() not in ('from', ''):
@@ -599,7 +599,10 @@ class DropZone(QFrame):
             return []
 
         if not descriptor_bytes or not content_bytes:
-            print(f"[DropZone] Empty descriptor ({len(descriptor_bytes)}) or content ({len(content_bytes)})", flush=True)
+            print(  # noqa: E501
+                f"[DropZone] Empty descriptor ({len(descriptor_bytes)}) or content ({len(content_bytes)})",
+                flush=True,
+            )
             return []
 
         # Parse FILEGROUPDESCRIPTOR(W): 4-byte count, then FILEDESCRIPTOR structs.
@@ -723,7 +726,7 @@ class DropZone(QFrame):
 
             if saved:
                 return [eml_path] + saved  # email first, then attachments
-            print(f"[DropZone] No attachments in .eml", flush=True)
+            print("[DropZone] No attachments in .eml", flush=True)
             return [eml_path]
 
         except Exception as e:
@@ -1250,8 +1253,8 @@ class FilePreviewWidget(QWidget):
     """
 
     _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.gif', '.bmp', '.tiff', '.tif', '.webp', '.ico'}
-    _CAD_EXTS   = {'.step', '.stp', '.iges', '.igs', '.x_t', '.x_b', '.prt', '.asm'}
-    _MESH_EXTS  = {'.stl', '.obj', '.ply', '.3mf'}
+    _CAD_EXTS = {'.step', '.stp', '.iges', '.igs', '.x_t', '.x_b', '.prt', '.asm'}
+    _MESH_EXTS = {'.stl', '.obj', '.ply', '.3mf'}
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -1389,7 +1392,7 @@ class FilePreviewWidget(QWidget):
         raise AssertionError("unreachable")
 
 
-def _draw_image_fitted(painter: 'QPainter', img: 'QImage', page_rect: 'QRectF') -> None:  # type: ignore[name-defined]
+def _draw_image_fitted(painter: 'QPainter', img: 'QImage', page_rect: 'QRectF') -> None:  # type: ignore[name-defined]  # noqa: F821
     """Draw img centred and scaled to fit page_rect preserving aspect ratio."""
     from PyQt6.QtCore import QRectF as _QRectF
     img_ratio = img.width() / max(img.height(), 1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,5 @@
 """Tests for shared/utils.py — pure functions only (no Qt, no filesystem side-effects)."""
 
-import pytest
 from shared.utils import (
     is_blueprint_file,
     parse_job_numbers,


### PR DESCRIPTION
## Summary
- Remove unused `QCheckBox` import from `shared/widgets.py`
- Rename ambiguous variable `l` → `ln` in Outlook MIME parser
- Wrap overlong print statement (E501)
- Remove f-string placeholder from plain string literal (F541)
- Fix alignment spaces on class-level set literals (E221)
- Add `# noqa: F821` to forward-reference type hints on `_draw_image_fitted`
- Remove unused `pytest` import from `tests/test_utils.py`

## Test plan
- [ ] `python3 -m py_compile shared/widgets.py` passes
- [ ] `flake8 shared/widgets.py tests/test_utils.py` returns no E/F errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code cleanup and optimizations for improved maintainability.

* **Tests**
  * Removed unused import dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->