### PR TITLE
fix: resolve remaining flake8 audit findings across all modules

### DIFF
--- a/core/module_loader.py
+++ b/core/module_loader.py
@@ -198,9 +198,9 @@ class ModuleLoader:
         module_class = None
         for name in dir(module):
             obj = getattr(module, name)
-            if (isinstance(obj, type) and
-                issubclass(obj, BaseModule) and
-                obj is not BaseModule):
+            if (isinstance(obj, type)
+                    and issubclass(obj, BaseModule)
+                    and obj is not BaseModule):
                 module_class = obj
                 break
 

--- a/modules/_template/module.py
+++ b/modules/_template/module.py
@@ -12,18 +12,18 @@ INSTRUCTIONS:
 5. That's it! The module loader will automatically discover it
 """
 
-import os
+import os  # noqa: F401
 import sys
 from pathlib import Path
 from typing import List, Any
-from PyQt6.QtWidgets import (
+from PyQt6.QtWidgets import (  # noqa: F401
     QWidget, QVBoxLayout, QLabel, QPushButton, QMessageBox
 )
-from PyQt6 import uic
+from PyQt6 import uic  # noqa: F401
 
 from core.base_module import BaseModule
-from shared.widgets import DropZone  # Optional: if you need file drops
-from shared.utils import get_os_text  # Optional: if you need OS-specific text
+from shared.widgets import DropZone  # noqa: F401  # Optional: if you need file drops
+from shared.utils import get_os_text  # noqa: F401  # Optional: if you need OS-specific text
 
 
 class TemplateModule(BaseModule):

--- a/modules/add_to_job/module.py
+++ b/modules/add_to_job/module.py
@@ -11,9 +11,9 @@ import shutil
 from pathlib import Path
 from typing import List
 from PyQt6.QtWidgets import (
-    QWidget, QMessageBox, QTreeWidgetItem, QButtonGroup
+    QWidget, QTreeWidgetItem, QButtonGroup
 )
-from PyQt6.QtCore import Qt, QTimer, QThread, pyqtSignal
+from PyQt6.QtCore import Qt, QThread, pyqtSignal
 from PyQt6 import uic
 
 from core.base_module import BaseModule
@@ -51,7 +51,10 @@ class JobTreeWorker(QThread):
                 if self.show_all_customers:
                     customers = [d for d in os.listdir(cf_dir) if os.path.isdir(os.path.join(cf_dir, d))]
                 else:
-                    customers = [self.selected_customer] if os.path.isdir(os.path.join(cf_dir, self.selected_customer)) else []
+                    customers = (
+                        [self.selected_customer]
+                        if os.path.isdir(os.path.join(cf_dir, self.selected_customer)) else []
+                    )
 
                 for customer in sorted(customers):
                     if self._is_cancelled:

--- a/modules/import_bp/module.py
+++ b/modules/import_bp/module.py
@@ -10,8 +10,7 @@ import sys
 import shutil
 from pathlib import Path
 from typing import List
-from PyQt6.QtWidgets import QWidget, QMessageBox
-from PyQt6.QtCore import QTimer
+from PyQt6.QtWidgets import QWidget
 from PyQt6 import uic
 
 from core.base_module import BaseModule

--- a/modules/job/module.py
+++ b/modules/job/module.py
@@ -13,7 +13,7 @@ import shutil
 from pathlib import Path
 from typing import List
 from PyQt6.QtWidgets import (
-    QWidget, QTreeWidgetItem, QButtonGroup, QCheckBox, QAbstractItemView
+    QWidget, QTreeWidgetItem, QButtonGroup, QAbstractItemView
 )
 
 from PyQt6.QtCore import Qt, QThread, pyqtSignal

--- a/modules/quote/module.py
+++ b/modules/quote/module.py
@@ -13,7 +13,7 @@ import shutil
 from pathlib import Path
 from typing import List
 from PyQt6.QtWidgets import (
-    QWidget, QTreeWidgetItem, QButtonGroup, QCheckBox, QAbstractItemView
+    QWidget, QTreeWidgetItem, QButtonGroup, QAbstractItemView
 )
 from PyQt6.QtCore import Qt, QThread, pyqtSignal
 from PyQt6 import uic

--- a/modules/reporting/module.py
+++ b/modules/reporting/module.py
@@ -10,7 +10,7 @@ import csv
 from pathlib import Path
 from datetime import datetime
 from PyQt6.QtWidgets import (
-    QWidget, QMessageBox, QTableWidgetItem, QFileDialog, QHeaderView, QAbstractItemView
+    QWidget, QTableWidgetItem, QFileDialog, QHeaderView, QAbstractItemView
 )
 from PyQt6 import uic
 

--- a/modules/search/module.py
+++ b/modules/search/module.py
@@ -92,8 +92,10 @@ class SearchWorker(QThread):
                 continue
 
             try:
-                customers = [d for d in os.listdir(base_dir)
-                           if os.path.isdir(os.path.join(base_dir, d))]
+                customers = [
+                    d for d in os.listdir(base_dir)
+                    if os.path.isdir(os.path.join(base_dir, d))
+                ]
             except OSError:
                 continue
 

--- a/shared/widgets.py
+++ b/shared/widgets.py
@@ -1392,7 +1392,9 @@ class FilePreviewWidget(QWidget):
         raise AssertionError("unreachable")
 
 
-def _draw_image_fitted(painter: 'QPainter', img: 'QImage', page_rect: 'QRectF') -> None:  # type: ignore[name-defined]  # noqa: F821
+def _draw_image_fitted(
+        painter: 'QPainter', img: 'QImage', page_rect: 'QRectF',  # noqa: F821
+) -> None:  # type: ignore[name-defined]
     """Draw img centred and scaled to fit page_rect preserving aspect ratio."""
     from PyQt6.QtCore import QRectF as _QRectF
     img_ratio = img.width() / max(img.height(), 1)
@@ -1432,7 +1434,7 @@ def print_files_with_dialog(paths: list, parent=None, app_context=None) -> None:
     _RENDERABLE = _IMAGE_EXTS | {'.pdf'}
 
     renderable = [p for p in paths if os.path.isfile(p) and Path(p).suffix.lower() in _RENDERABLE]
-    fallback   = [p for p in paths if os.path.isfile(p) and Path(p).suffix.lower() not in _RENDERABLE]
+    fallback = [p for p in paths if os.path.isfile(p) and Path(p).suffix.lower() not in _RENDERABLE]
 
     cancelled = False
     failed_pre_render: list[str] = []


### PR DESCRIPTION
## Summary
Final batch of flake8 audit cleanup — codebase is now fully clean:

- **shared/widgets.py** — fix F821 noqa placement on forward-ref type hints, fix E221 alignment
- **core/module_loader.py** — fix E129 visually indented line
- **modules/search/module.py** — fix E128 continuation line indentation
- **modules/_template/module.py** — add noqa: F401 to intentional scaffold imports
- **modules/add_to_job/module.py** — remove unused QMessageBox/QTimer, wrap long line
- **modules/import_bp/module.py** — remove unused QMessageBox/QTimer
- **modules/reporting/module.py** — remove unused QMessageBox
- **modules/job/module.py** — remove unused QCheckBox
- **modules/quote/module.py** — remove unused QCheckBox

`flake8 --select=E,F` now returns zero findings on all active source files.

## Test plan
- [ ] `python3 -m flake8 --max-line-length=120 --select=E,F --exclude=.git,__pycache__,build_scripts,linux,old .` returns clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code formatting and readability across multiple modules through conditional statement restructuring and list comprehension reformatting.

* **Chores**
  * Removed unused imports and added linter suppressions for internal code quality improvements.

**Impact to Users:** No functional changes; internal code maintenance release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->