### PR TITLE
fix: suppress bandit B310 false positives in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -104,7 +104,7 @@ class _PluginInstallWorker(QThread):
         try:
             api_url = f"https://api.github.com/repos/{owner}/{repo}"
             req = urllib.request.Request(api_url, headers={"Accept": "application/vnd.github+json"})
-            with urllib.request.urlopen(req, timeout=15) as resp:
+            with urllib.request.urlopen(req, timeout=15) as resp:  # nosec B310
                 meta = json.loads(resp.read())
             branches_to_try = [meta.get("default_branch", "main")]
         except Exception:
@@ -115,7 +115,7 @@ class _PluginInstallWorker(QThread):
             zip_url = f"https://github.com/{owner}/{repo}/archive/refs/heads/{branch}.zip"
             try:
                 self.status.emit(f"Downloading {owner}/{repo}...")
-                with urllib.request.urlopen(zip_url, timeout=30) as resp:
+                with urllib.request.urlopen(zip_url, timeout=30) as resp:  # nosec B310
                     zip_data = resp.read()
 
                 self.status.emit("Extracting files...")


### PR DESCRIPTION
## Summary
- Adds `# nosec B310` to two `urlopen` calls in `main.py` (lines 107 and 118)
- Both use hardcoded `https://` GitHub URLs — no user-controlled input, not a real vulnerability
- Closes #209, #210

## Test plan
- [ ] `bandit -r main.py --severity-level medium` returns zero findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)