### PR TITLE
fix: correct license to GPL-3.0-or-later throughout

### DIFF
--- a/experimental/db_integration.py
+++ b/experimental/db_integration.py
@@ -3,7 +3,7 @@ Database Integration Module for JobDocs
 Placeholder code for connecting to JobBOSS, ERP systems, or other SQL databases
 
 Copyright (c) 2025 JobDocs Contributors
-Licensed under the MIT License - see LICENSE file for details
+Licensed under the GNU General Public License v3.0 - see LICENSE file for details
 
 This module provides a foundation for:
 - Connecting to various database types (MSSQL, MySQL, PostgreSQL)

--- a/linux/flatpak/io.github.i_machine_things.JobDocs.metainfo.xml
+++ b/linux/flatpak/io.github.i_machine_things.JobDocs.metainfo.xml
@@ -3,7 +3,7 @@
   <id>io.github.i_machine_things.JobDocs</id>
 
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>MIT</project_license>
+  <project_license>GPL-3.0-or-later</project_license>
 
   <name>JobDocs</name>
   <summary>Manage blueprint files and customer job directories</summary>


### PR DESCRIPTION
## Summary
- `linux/flatpak/io.github.i_machine_things.JobDocs.metainfo.xml`: `MIT` → `GPL-3.0-or-later`
- `experimental/db_integration.py`: docstring MIT reference → GPL-3.0

The `LICENSE` file in the repo root was already GPL-3. This aligns all references to match.

## Test plan
- [ ] Verify no remaining MIT license references in active source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)