### PR TITLE
fix: add developer info to Flatpak metainfo

### DIFF
--- a/linux/flatpak/io.github.i_machine_things.JobDocs.metainfo.xml
+++ b/linux/flatpak/io.github.i_machine_things.JobDocs.metainfo.xml
@@ -24,6 +24,10 @@
     </ul>
   </description>
 
+  <developer id="io.github.i_machine_things">
+    <name>i-machine-things</name>
+  </developer>
+
   <url type="homepage">https://github.com/i-machine-things/JobDocs</url>
   <url type="bugtracker">https://github.com/i-machine-things/JobDocs/issues</url>
 


### PR DESCRIPTION
## Summary
- Adds `<developer>` tag to metainfo XML so Flathub/GNOME Software shows the author instead of "Unknown author"

## Test plan
- [ ] Install Flatpak and confirm author displays as `i-machine-things`

🤖 Generated with [Claude Code](https://claude.com/claude-code)