### PR TITLE
feat: add screenshots and categories to Flatpak metainfo

### DIFF
--- a/linux/flatpak/io.github.i_machine_things.JobDocs.metainfo.xml
+++ b/linux/flatpak/io.github.i_machine_things.JobDocs.metainfo.xml
@@ -37,6 +37,34 @@
     <binary>JobDocs</binary>
   </provides>
 
+  <categories>
+    <category>Office</category>
+    <category>Utility</category>
+  </categories>
+
+  <screenshots>
+    <screenshot type="default">
+      <caption>Create a new job</caption>
+      <image>https://raw.githubusercontent.com/i-machine-things/JobDocs/master/docs/screenshots/job_create_new.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Create a new quote</caption>
+      <image>https://raw.githubusercontent.com/i-machine-things/JobDocs/master/docs/screenshots/quote_create_new.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Import blueprints</caption>
+      <image>https://raw.githubusercontent.com/i-machine-things/JobDocs/master/docs/screenshots/import_blueprints.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Search jobs and quotes</caption>
+      <image>https://raw.githubusercontent.com/i-machine-things/JobDocs/master/docs/screenshots/search.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Setup wizard</caption>
+      <image>https://raw.githubusercontent.com/i-machine-things/JobDocs/master/docs/screenshots/setup_wizard.png</image>
+    </screenshot>
+  </screenshots>
+
   <content_rating type="oars-1.1"/>
 
   <releases>


### PR DESCRIPTION
## Summary
- Adds 5 screenshots to metainfo (required for Flathub)
- Adds `Office` and `Utility` categories

## Test plan
- [ ] `appstreamcli validate` passes on the metainfo file

🤖 Generated with [Claude Code](https://claude.com/claude-code)