### PR TITLE
fix: add --share=network to Flatpak manifests

### DIFF
--- a/linux/flatpak/flathub/io.github.i_machine_things.JobDocs.yml
+++ b/linux/flatpak/flathub/io.github.i_machine_things.JobDocs.yml
@@ -10,6 +10,7 @@ finish-args:
   # Display — prefer Wayland, fall back to X11
   - --socket=wayland
   - --socket=fallback-x11
+  - --share=network
   - --share=ipc
   # GPU acceleration for Qt rendering
   - --device=dri

--- a/linux/flatpak/io.github.i_machine_things.JobDocs.yml
+++ b/linux/flatpak/io.github.i_machine_things.JobDocs.yml
@@ -8,6 +8,7 @@ finish-args:
   # Display — prefer Wayland, fall back to X11
   - --socket=wayland
   - --socket=fallback-x11
+  - --share=network
   - --share=ipc
   # GPU acceleration for Qt rendering
   - --device=dri


### PR DESCRIPTION
## Summary
- Adds `--share=network` to both Flatpak manifests (CI and Flathub)
- Fixes plugin installer failing with `urlopen error [Errno -3] Temporary failure in name resolution`
- Required for Report Fixer download from GitHub and any future network features

🤖 Generated with [Claude Code](https://claude.com/claude-code)