### PR TITLE
feat: add Uninstall Plugin menu action

### DIFF
--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -2070,3 +2070,11 @@ Actionable: ?  Nitpicks: 1
 
 Actionable: 1  Nitpicks: 0
 - Configuration used
+
+---
+
+## 2026-04-24 — `PR #227: feat: add Uninstall Plugin menu action` — run 3
+
+Actionable: ?  Nitpicks: 1
+- Consider reusing shared plugin discovery logic to avoid drift.
+- Configuration used

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -2038,3 +2038,10 @@ Actionable: 2  Nitpicks: 0
 Actionable: 1  Nitpicks: 0
 - Use Flatpak's host `/etc` mapping instead of `/etc/papersize`.
 - Configuration used
+
+---
+
+## 2026-04-23 — `PR #227: feat: add Uninstall Plugin menu action` — run 1
+
+Actionable: 1  Nitpicks: 0
+- Configuration used

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -2055,3 +2055,11 @@ Actionable: 1  Nitpicks: 0
 2. **Narrow broad `except Exception` on `shutil.rmtree`** — `main.py`
    - Overly broad catch can mask unexpected errors (S&P pattern from 2026-04-06)
    - Fix: changed to `except (OSError, shutil.Error)` — the only exceptions `rmtree` raises
+
+---
+
+## 2026-04-24 — `PR #227: feat: add Uninstall Plugin menu action` — run 1
+
+Actionable: ?  Nitpicks: 1
+- Consider sorting plugin names for deterministic selection UX.
+- Configuration used

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -2043,5 +2043,15 @@ Actionable: 1  Nitpicks: 0
 
 ## 2026-04-23 — `PR #227: feat: add Uninstall Plugin menu action` — run 1
 
-Actionable: 1  Nitpicks: 0
-- Configuration used
+**Review:** CodeRabbit flagged unsafe exception handling in `uninstall_plugin`.
+**Result:** Both fixes applied.
+
+### Findings
+
+1. **Wrap `plugins_dir.iterdir()` in `OSError` handler** — `main.py`
+   - Directory scan could raise `OSError` (e.g. permission denied, path removed between check and scan)
+   - Fix: wrapped list comprehension in `try/except OSError`; shows `QMessageBox.critical` and returns
+
+2. **Narrow broad `except Exception` on `shutil.rmtree`** — `main.py`
+   - Overly broad catch can mask unexpected errors (S&P pattern from 2026-04-06)
+   - Fix: changed to `except (OSError, shutil.Error)` — the only exceptions `rmtree` raises

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -2063,3 +2063,10 @@ Actionable: 1  Nitpicks: 0
 Actionable: ?  Nitpicks: 1
 - Consider sorting plugin names for deterministic selection UX.
 - Configuration used
+
+---
+
+## 2026-04-24 — `PR #227: feat: add Uninstall Plugin menu action` — run 2
+
+Actionable: 1  Nitpicks: 0
+- Configuration used

--- a/main.py
+++ b/main.py
@@ -634,13 +634,19 @@ class JobDocsMainWindow(QMainWindow):
             return
 
         try:
-            installed = sorted(
-                [d for d in plugins_dir.iterdir() if d.is_dir() and (d / "module.py").exists()],
-                key=lambda p: p.name.lower(),
-            )
+            entries = list(plugins_dir.iterdir())
         except OSError as e:
             QMessageBox.critical(self, "Uninstall Plugin", f"Could not scan plugins directory:\n{e}")
             return
+
+        installed_raw = []
+        for d in entries:
+            try:
+                if d.is_dir() and (d / "module.py").exists():
+                    installed_raw.append(d)
+            except OSError:
+                pass
+        installed = sorted(installed_raw, key=lambda p: p.name.lower())
         if not installed:
             QMessageBox.information(self, "Uninstall Plugin", "No installed plugins found.")
             return

--- a/main.py
+++ b/main.py
@@ -634,7 +634,10 @@ class JobDocsMainWindow(QMainWindow):
             return
 
         try:
-            installed = [d for d in plugins_dir.iterdir() if d.is_dir() and (d / "module.py").exists()]
+            installed = sorted(
+                [d for d in plugins_dir.iterdir() if d.is_dir() and (d / "module.py").exists()],
+                key=lambda p: p.name.lower(),
+            )
         except OSError as e:
             QMessageBox.critical(self, "Uninstall Plugin", f"Could not scan plugins directory:\n{e}")
             return

--- a/main.py
+++ b/main.py
@@ -500,6 +500,9 @@ class JobDocsMainWindow(QMainWindow):
         install_plugin_action = file_menu.addAction("&Install Plugin...")  # pyright: ignore[reportOptionalMemberAccess]
         install_plugin_action.triggered.connect(self.install_plugin)  # pyright: ignore[reportOptionalMemberAccess]
 
+        uninstall_plugin_action = file_menu.addAction("&Uninstall Plugin...")  # pyright: ignore[reportOptionalMemberAccess]
+        uninstall_plugin_action.triggered.connect(self.uninstall_plugin)  # pyright: ignore[reportOptionalMemberAccess]
+
         file_menu.addSeparator()  # pyright: ignore[reportOptionalMemberAccess]
 
         exit_action = file_menu.addAction("E&xit")  # pyright: ignore[reportOptionalMemberAccess]
@@ -622,6 +625,51 @@ class JobDocsMainWindow(QMainWindow):
         self._install_progress.close()
         QMessageBox.critical(self, "Install Plugin", message)
         worker.deleteLater()
+
+    def uninstall_plugin(self):
+        """List installed plugins and remove the one the user selects."""
+        plugins_dir = self._get_plugins_dir()
+        if not plugins_dir or not plugins_dir.exists():
+            QMessageBox.information(self, "Uninstall Plugin", "No plugins directory found.")
+            return
+
+        installed = [d for d in plugins_dir.iterdir() if d.is_dir() and (d / "module.py").exists()]
+        if not installed:
+            QMessageBox.information(self, "Uninstall Plugin", "No installed plugins found.")
+            return
+
+        names = [d.name for d in installed]
+        choice, ok = QInputDialog.getItem(
+            self, "Uninstall Plugin", "Select plugin to uninstall:", names, 0, False
+        )
+        if not ok or not choice:
+            return
+
+        confirm = QMessageBox.question(
+            self, "Uninstall Plugin",
+            f"Remove plugin '{choice}'? This cannot be undone.",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+        )
+        if confirm != QMessageBox.StandardButton.Yes:
+            return
+
+        target = plugins_dir / choice
+        try:
+            shutil.rmtree(target)
+        except Exception as e:
+            QMessageBox.critical(self, "Uninstall Plugin", f"Failed to remove plugin:\n{e}")
+            return
+
+        disabled = self.settings.get("disabled_modules", [])
+        if choice in disabled:
+            disabled.remove(choice)
+            self.settings["disabled_modules"] = disabled
+            self.save_settings()
+
+        QMessageBox.information(
+            self, "Uninstall Plugin",
+            f"Plugin '{choice}' removed. Restart JobDocs to complete uninstall."
+        )
 
     def show_getting_started(self):
         """Show getting started guide"""

--- a/main.py
+++ b/main.py
@@ -633,7 +633,11 @@ class JobDocsMainWindow(QMainWindow):
             QMessageBox.information(self, "Uninstall Plugin", "No plugins directory found.")
             return
 
-        installed = [d for d in plugins_dir.iterdir() if d.is_dir() and (d / "module.py").exists()]
+        try:
+            installed = [d for d in plugins_dir.iterdir() if d.is_dir() and (d / "module.py").exists()]
+        except OSError as e:
+            QMessageBox.critical(self, "Uninstall Plugin", f"Could not scan plugins directory:\n{e}")
+            return
         if not installed:
             QMessageBox.information(self, "Uninstall Plugin", "No installed plugins found.")
             return
@@ -656,7 +660,7 @@ class JobDocsMainWindow(QMainWindow):
         target = plugins_dir / choice
         try:
             shutil.rmtree(target)
-        except Exception as e:
+        except (OSError, shutil.Error) as e:
             QMessageBox.critical(self, "Uninstall Plugin", f"Failed to remove plugin:\n{e}")
             return
 


### PR DESCRIPTION
## Summary
- Adds **File → Uninstall Plugin...** menu action
- Lists all installed plugins (dirs in `plugins_dir` containing `module.py`)
- Prompts user to select one, confirms before deleting
- Removes the plugin directory via `shutil.rmtree`
- Cleans up `disabled_modules` setting if the plugin was listed there
- Informs user to restart to complete uninstall

Closes #225

## Test plan
- [ ] Install a plugin, then uninstall it via File → Uninstall Plugin...
- [ ] Confirm plugin directory is removed from plugins_dir
- [ ] Confirm cancelling at any step leaves plugin intact
- [ ] Confirm error dialog appears if removal fails (e.g. file locked)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Uninstall Plugin" option in the File menu. Users can browse installed plugins, confirm irreversible removal, and receive a success message recommending a restart. The app updates stored settings after removal and shows informative dialogs if the plugins folder is missing, scanning fails, no plugins are found, or removal cannot be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->