### PR TITLE
fix: use frozenset for deprecated_modules in module_loader

### DIFF
--- a/core/module_loader.py
+++ b/core/module_loader.py
@@ -59,7 +59,7 @@ class ModuleLoader:
         is_frozen = getattr(sys, 'frozen', False)
 
         # Deprecated modules (kept in codebase but not loaded)
-        deprecated_modules = {'add_to_job'}
+        deprecated_modules = frozenset({'add_to_job'})
 
         if is_frozen:
             # In frozen mode, start with the hardcoded list of built-in modules.


### PR DESCRIPTION
## Summary
- Changes `deprecated_modules` from a mutable `set` to `frozenset` in `ModuleLoader.discover_modules`
- The set is never mutated after creation; `frozenset` signals intent and is consistent with `_SKIP_EXTS`/`_IMAGE_EXTS` in `widgets.py`

## Test plan
- [ ] App loads all modules normally
- [ ] Deprecated module `add_to_job` is still excluded from the tab list

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code stability improvement to prevent accidental modifications to module handling. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->