### PR TITLE
fix: use host-etc filesystem permission in Flatpak manifest

### DIFF
--- a/linux/flatpak/io.github.i_machine_things.JobDocs.yml
+++ b/linux/flatpak/io.github.i_machine_things.JobDocs.yml
@@ -20,7 +20,7 @@ finish-args:
   # TODO: replace with --filesystem=xdg-data/JobDocs + portal-based dir picker
   #       once core/settings_dialog.py uses QFileDialog with portal support.
   - --filesystem=home
-  - --filesystem=/etc/papersize:ro
+  - --filesystem=host-etc:ro
 
 modules:
   - name: JobDocs


### PR DESCRIPTION
## Summary
- Replaces `--filesystem=/etc/papersize:ro` with `--filesystem=host-etc:ro` in the non-Flathub Flatpak manifest
- The code in `shared/widgets.py` already reads from `/run/host/etc/papersize` (the path exposed by `host-etc`), so the narrow `/etc/papersize` permission never worked inside the sandbox
- Aligns the non-Flathub manifest with the Flathub manifest which already has `host-etc:ro`

## Test plan
- [ ] Build Flatpak with updated manifest
- [ ] Verify papersize detection works correctly on a Linux host with `/etc/papersize` set

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application system permissions to improve compatibility with Linux system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->