### PR TITLE
fix: resolve flake8 audit findings (E241, E302, E305, E402, E501)

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,6 +27,10 @@ from PyQt6.QtWidgets import (
 )
 
 from core.module_loader import ModuleLoader
+from core.app_context import AppContext
+from shared.utils import get_config_dir, get_os_text
+from shared.remote_sync import RemoteSyncManager
+
 
 def _get_app_version() -> str:
     try:
@@ -238,10 +242,8 @@ def _flatpak_dns_fix() -> None:
 
     socket.getaddrinfo = _getaddrinfo
 
+
 _flatpak_dns_fix()
-from core.app_context import AppContext
-from shared.utils import get_config_dir, get_os_text
-from shared.remote_sync import RemoteSyncManager
 
 
 class _PluginInstallWorker(QThread):
@@ -720,7 +722,8 @@ class JobDocsMainWindow(QMainWindow):
         install_plugin_action = file_menu.addAction("&Install Plugin...")  # pyright: ignore[reportOptionalMemberAccess]
         install_plugin_action.triggered.connect(self.install_plugin)  # pyright: ignore[reportOptionalMemberAccess]
 
-        uninstall_plugin_action = file_menu.addAction("&Uninstall Plugin...")  # pyright: ignore[reportOptionalMemberAccess]
+        uninstall_plugin_action = file_menu.addAction(  # pyright: ignore[reportOptionalMemberAccess]
+            "&Uninstall Plugin...")
         uninstall_plugin_action.triggered.connect(self.uninstall_plugin)  # pyright: ignore[reportOptionalMemberAccess]
 
         file_menu.addSeparator()  # pyright: ignore[reportOptionalMemberAccess]
@@ -745,8 +748,10 @@ class JobDocsMainWindow(QMainWindow):
         check_updates_action = help_menu.addAction("Check for &Updates")  # pyright: ignore[reportOptionalMemberAccess]
         check_updates_action.triggered.connect(self.check_for_updates)  # pyright: ignore[reportOptionalMemberAccess]
 
-        enable_updates_action = help_menu.addAction("Re-enable Update &Notifications")  # pyright: ignore[reportOptionalMemberAccess]
-        enable_updates_action.triggered.connect(self.reenable_update_notifications)  # pyright: ignore[reportOptionalMemberAccess]
+        enable_updates_action = help_menu.addAction(  # pyright: ignore[reportOptionalMemberAccess]
+            "Re-enable Update &Notifications")
+        enable_updates_action.triggered.connect(  # pyright: ignore[reportOptionalMemberAccess]
+            self.reenable_update_notifications)
 
         help_menu.addSeparator()  # pyright: ignore[reportOptionalMemberAccess]
 

--- a/shared/widgets.py
+++ b/shared/widgets.py
@@ -1708,12 +1708,12 @@ def print_files_with_dialog(paths: list, parent=None, app_context=None) -> None:
                 QDialog, QDialogButtonBox, QFormLayout, QComboBox, QSpinBox,
             )
             _PAGE_SIZES = [
-                ('Letter (8.5 × 11")',  QPageSize.PageSizeId.Letter),
-                ('Legal (8.5 × 14")',   QPageSize.PageSizeId.Legal),
-                ('Tabloid (11 × 17")',  QPageSize.PageSizeId.Tabloid),
-                ('A3',                  QPageSize.PageSizeId.A3),
-                ('A4',                  QPageSize.PageSizeId.A4),
-                ('A5',                  QPageSize.PageSizeId.A5),
+                ('Letter (8.5 × 11")', QPageSize.PageSizeId.Letter),
+                ('Legal (8.5 × 14")', QPageSize.PageSizeId.Legal),
+                ('Tabloid (11 × 17")', QPageSize.PageSizeId.Tabloid),
+                ('A3', QPageSize.PageSizeId.A3),
+                ('A4', QPageSize.PageSizeId.A4),
+                ('A5', QPageSize.PageSizeId.A5),
             ]
 
             preview = QPrintPreviewDialog(preview_printer, parent)


### PR DESCRIPTION
## Summary

- **E302** (`main.py`) — added second blank line before `_get_app_version()`
- **E305** (`main.py`) — added second blank line after `_flatpak_dns_fix()` definition
- **E402** (`main.py`) — moved `AppContext`, `utils`, `RemoteSyncManager` imports to the top-level import block
- **E501** (`main.py`) — wrapped three lines over 120 chars
- **E241** (`shared/widgets.py`) — removed alignment spaces after commas in `_PAGE_SIZES`

Closes #230, #231, #232, #233, #234, #235, #236, #237, #238, #239, #240, #241

## Test plan
- [x] App launches without import errors
- [x] Flake8 passes on `main.py` and `shared/widgets.py`
- [x] Help → Check for Updates menu item still visible and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements for enhanced maintainability.

* **Style**
  * Code formatting and whitespace refinements across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->