### PR TITLE
feat: PO/RFQ detection and flagging

### DIFF
--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -2247,3 +2247,11 @@ Actionable: 3  Nitpicks: 0 — all resolved
 Actionable: ?  Nitpicks: 1
 - Bound `_classify_cache` to avoid unbounded growth in long-running sessions.
 - Configuration used
+
+---
+
+## 2026-04-28 — `PR #244: feat: PO/RFQ detection and flagging` — run 2
+
+Actionable: 1  Nitpicks: 0
+- Narrow PDF parse exception handling and keep traceback in debug logs.
+- Configuration used

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -2214,3 +2214,11 @@ Actionable: 3  Nitpicks: 0 — all resolved
 3. **`except` block emits `up_to_date` on network/parse errors** — `main.py` `_UpdateChecker.run`
    - Any error (DNS failure, timeout, malformed JSON) silently showed "You're up to date"
    - Fix: catch only expected exceptions (`URLError`, `OSError`, `JSONDecodeError`, `ValueError`) and pass; `up_to_date` only emits on a confirmed successful check
+
+---
+
+## 2026-04-28 — `PR #244: feat: PO/RFQ detection and flagging` — run 1
+
+Actionable: 3  Nitpicks: 1
+- Tag flagged rows in item data so bulk actions can safely skip them.
+- Configuration used

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -2239,3 +2239,11 @@ Actionable: 3  Nitpicks: 0 — all resolved
 4. **"Save as Document" has no distinct routing** — by design
    - CR suggested an `is_document` flag or explicit move helper
    - Files in `job_files`/`quote_files` are always copied (never blueprint-linked); "Save as Document" is the correct label for keeping the file in that list. No flag needed.
+
+---
+
+## 2026-04-28 — `PR #244: feat: PO/RFQ detection and flagging` — run 1
+
+Actionable: ?  Nitpicks: 1
+- Bound `_classify_cache` to avoid unbounded growth in long-running sessions.
+- Configuration used

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -2222,3 +2222,10 @@ Actionable: 3  Nitpicks: 0 — all resolved
 Actionable: 3  Nitpicks: 1
 - Tag flagged rows in item data so bulk actions can safely skip them.
 - Configuration used
+
+---
+
+## 2026-04-28 — `PR #244: feat: PO/RFQ detection and flagging` — run 2
+
+Actionable: 1  Nitpicks: 0
+- Configuration used

--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -2217,15 +2217,25 @@ Actionable: 3  Nitpicks: 0 — all resolved
 
 ---
 
-## 2026-04-28 — `PR #244: feat: PO/RFQ detection and flagging` — run 1
+## 2026-04-28 — `PR #244: feat: PO/RFQ detection and flagging`
 
-Actionable: 3  Nitpicks: 1
-- Tag flagged rows in item data so bulk actions can safely skip them.
-- Configuration used
+**Review:** PO/RFQ detection across job/quote file-add flows. Two CR runs.
+**Result:** 3 actionable + 1 nitpick — all resolved.
 
----
+### Findings
 
-## 2026-04-28 — `PR #244: feat: PO/RFQ detection and flagging` — run 2
+1. **Silent `except Exception: pass` in `classify_document`** — `shared/utils.py`
+   - Swallows all PDF read errors with no diagnostic trace
+   - Fix: `except Exception as e: logger.debug(...)` — preserves graceful fallback, visible in debug logs
 
-Actionable: 1  Nitpicks: 0
-- Configuration used
+2. **`classify_document` blocks the UI thread** — `shared/widgets.py`
+   - Called in the draw-results loop for up to 200 files; PDF parsing adds 0.1–0.5 s per file
+   - Fix: mtime-keyed module-level cache (`_classify_cache`) — first call parses, subsequent hits return instantly
+
+3. **No machine-readable flag on PO/RFQ rows** — `shared/widgets.py`
+   - Visual styling alone can't be queried; `Select All` would check flagged rows
+   - Fix: `item.setData(0, Qt.ItemDataRole.UserRole + 1, True)`; `_select_all` skips flagged rows
+
+4. **"Save as Document" has no distinct routing** — by design
+   - CR suggested an `is_document` flag or explicit move helper
+   - Files in `job_files`/`quote_files` are always copied (never blueprint-linked); "Save as Document" is the correct label for keeping the file in that list. No flag needed.

--- a/core/base_module.py
+++ b/core/base_module.py
@@ -6,7 +6,9 @@ This enables dynamic loading and ensures consistent behavior across modules.
 """
 
 from abc import ABC, abstractmethod
-from PyQt6.QtWidgets import QWidget
+from pathlib import Path
+from typing import List
+from PyQt6.QtWidgets import QMessageBox, QWidget
 
 
 class BaseModule(ABC):
@@ -158,3 +160,35 @@ class BaseModule(ABC):
         """
         if self._app_context:
             self._app_context.show_info(title, message)
+
+    def _check_po_rfq_files(self, newly_added: List[str], files_store: List[str], list_widget) -> None:
+        """Scan newly-added files for PO/RFQ signals and prompt the user for each flagged file.
+
+        Only files whose extension matches the configured blueprint extensions are checked —
+        non-drawing files (.msg, .docx, etc.) are always documents and need no prompt.
+        """
+        from shared.utils import classify_document
+        bp_exts = [e.lower() for e in self.app_context.get_setting('blueprint_extensions', ['.pdf', '.dwg', '.dxf'])]
+        for path in list(newly_added):
+            if Path(path).suffix.lower() not in bp_exts:
+                continue
+            is_flagged, reason = classify_document(path)
+            if not is_flagged:
+                continue
+            filename = Path(path).name
+            msg = QMessageBox(self._widget)
+            msg.setWindowTitle("PO / RFQ Detected")
+            msg.setIcon(QMessageBox.Icon.Warning)
+            msg.setText(f"'{filename}' appears to be a Purchase Order or RFQ.")
+            msg.setInformativeText(
+                f"Detected: {reason}\n\n"
+                "Save it as a document in the job folder, or remove it from the list?"
+            )
+            save_btn = msg.addButton("Save as Document", QMessageBox.ButtonRole.AcceptRole)
+            remove_btn = msg.addButton("Remove", QMessageBox.ButtonRole.RejectRole)
+            msg.setDefaultButton(save_btn)
+            msg.exec()
+            if msg.clickedButton() is remove_btn and path in files_store:
+                idx = files_store.index(path)
+                files_store.pop(idx)
+                list_widget.takeItem(idx)

--- a/modules/job/module.py
+++ b/modules/job/module.py
@@ -13,7 +13,7 @@ import shutil
 from pathlib import Path
 from typing import List
 from PyQt6.QtWidgets import (
-    QWidget, QTreeWidgetItem, QButtonGroup, QAbstractItemView, QMessageBox
+    QWidget, QTreeWidgetItem, QButtonGroup, QAbstractItemView
 )
 
 from PyQt6.QtCore import Qt, QThread, pyqtSignal
@@ -27,7 +27,7 @@ from shared.widgets import (
 )
 from shared.utils import (
     is_blueprint_file, parse_job_numbers, create_file_link,
-    sanitize_filename, open_folder, get_next_number, classify_document
+    sanitize_filename, open_folder, get_next_number
 )
 
 
@@ -301,37 +301,6 @@ class JobModule(BaseModule):
         if self.add_preview is None:
             return
         self.add_preview.preview_file(self.add_files[row] if 0 <= row < len(self.add_files) else None)
-
-    def _check_po_rfq_files(self, newly_added: List[str], files_store: List[str], list_widget) -> None:
-        """Scan newly-added files for PO/RFQ signals and prompt the user for each flagged file.
-
-        Only files whose extension matches the configured blueprint extensions are checked —
-        non-drawing files (.msg, .docx, etc.) are always documents and need no prompt.
-        """
-        bp_exts = [e.lower() for e in self.app_context.get_setting('blueprint_extensions', ['.pdf', '.dwg', '.dxf'])]
-        for path in list(newly_added):
-            if Path(path).suffix.lower() not in bp_exts:
-                continue
-            is_flagged, reason = classify_document(path)
-            if not is_flagged:
-                continue
-            filename = os.path.basename(path)
-            msg = QMessageBox(self._widget)
-            msg.setWindowTitle("PO / RFQ Detected")
-            msg.setIcon(QMessageBox.Icon.Warning)
-            msg.setText(f"'{filename}' appears to be a Purchase Order or RFQ.")
-            msg.setInformativeText(
-                f"Detected: {reason}\n\n"
-                "Save it as a document in the job folder, or remove it from the list?"
-            )
-            save_btn = msg.addButton("Save as Document", QMessageBox.ButtonRole.AcceptRole)
-            remove_btn = msg.addButton("Remove", QMessageBox.ButtonRole.RejectRole)
-            msg.setDefaultButton(save_btn)
-            msg.exec()
-            if msg.clickedButton() is remove_btn and path in files_store:
-                idx = files_store.index(path)
-                files_store.pop(idx)
-                list_widget.takeItem(idx)
 
     def handle_job_files(self, files: List[str]):
         """Add files to the job files list (Create New tab)"""

--- a/modules/job/module.py
+++ b/modules/job/module.py
@@ -13,7 +13,7 @@ import shutil
 from pathlib import Path
 from typing import List
 from PyQt6.QtWidgets import (
-    QWidget, QTreeWidgetItem, QButtonGroup, QAbstractItemView
+    QWidget, QTreeWidgetItem, QButtonGroup, QAbstractItemView, QMessageBox
 )
 
 from PyQt6.QtCore import Qt, QThread, pyqtSignal
@@ -27,7 +27,7 @@ from shared.widgets import (
 )
 from shared.utils import (
     is_blueprint_file, parse_job_numbers, create_file_link,
-    sanitize_filename, open_folder, get_next_number
+    sanitize_filename, open_folder, get_next_number, classify_document
 )
 
 
@@ -302,12 +302,40 @@ class JobModule(BaseModule):
             return
         self.add_preview.preview_file(self.add_files[row] if 0 <= row < len(self.add_files) else None)
 
+    def _check_po_rfq_files(self, newly_added: List[str], files_store: List[str], list_widget) -> None:
+        """Scan newly-added files for PO/RFQ signals and prompt the user for each flagged file."""
+        for path in list(newly_added):
+            is_flagged, reason = classify_document(path)
+            if not is_flagged:
+                continue
+            filename = os.path.basename(path)
+            msg = QMessageBox(self._widget)
+            msg.setWindowTitle("PO / RFQ Detected")
+            msg.setIcon(QMessageBox.Icon.Warning)
+            msg.setText(f"'{filename}' appears to be a Purchase Order or RFQ.")
+            msg.setInformativeText(
+                f"Detected: {reason}\n\n"
+                "Save it as a document in the job folder, or remove it from the list?"
+            )
+            save_btn = msg.addButton("Save as Document", QMessageBox.ButtonRole.AcceptRole)
+            remove_btn = msg.addButton("Remove", QMessageBox.ButtonRole.RejectRole)
+            msg.setDefaultButton(save_btn)
+            msg.exec()
+            if msg.clickedButton() is remove_btn and path in files_store:
+                idx = files_store.index(path)
+                files_store.pop(idx)
+                list_widget.takeItem(idx)
+
     def handle_job_files(self, files: List[str]):
         """Add files to the job files list (Create New tab)"""
+        newly_added = []
         for f in files:
             if f not in self.job_files:
                 self.job_files.append(f)
                 self.job_files_list.addItem(os.path.basename(f))
+                newly_added.append(f)
+        if newly_added:
+            self._check_po_rfq_files(newly_added, self.job_files, self.job_files_list)
 
     def remove_job_file(self):
         """Remove selected file from job files list (Create New tab)"""
@@ -561,13 +589,17 @@ class JobModule(BaseModule):
             selected_files = dialog.get_selected_files()
             if selected_files:
                 files_added = 0
+                newly_added = []
                 for file_path in selected_files:
                     if file_path not in self.job_files:
                         self.job_files.append(file_path)
                         self.job_files_list.addItem(os.path.basename(file_path))
                         files_added += 1
+                        newly_added.append(file_path)
                 if files_added > 0:
                     self.log_message(f"Linked {files_added} drawing(s)")
+                if newly_added:
+                    self._check_po_rfq_files(newly_added, self.job_files, self.job_files_list)
 
     def _copy_info_from_folder(self, folder_path: str):
         """Copy job/quote info from folder to form, including optional file copy"""
@@ -771,10 +803,14 @@ class JobModule(BaseModule):
 
     def handle_add_files(self, files: List[str]):
         """Add files to the add files list (Add to Existing tab)"""
+        newly_added = []
         for f in files:
             if f not in self.add_files:
                 self.add_files.append(f)
                 self.add_files_list.addItem(os.path.basename(f))
+                newly_added.append(f)
+        if newly_added:
+            self._check_po_rfq_files(newly_added, self.add_files, self.add_files_list)
 
     def remove_add_file(self):
         """Remove selected file from add files list"""

--- a/modules/job/module.py
+++ b/modules/job/module.py
@@ -303,8 +303,15 @@ class JobModule(BaseModule):
         self.add_preview.preview_file(self.add_files[row] if 0 <= row < len(self.add_files) else None)
 
     def _check_po_rfq_files(self, newly_added: List[str], files_store: List[str], list_widget) -> None:
-        """Scan newly-added files for PO/RFQ signals and prompt the user for each flagged file."""
+        """Scan newly-added files for PO/RFQ signals and prompt the user for each flagged file.
+
+        Only files whose extension matches the configured blueprint extensions are checked —
+        non-drawing files (.msg, .docx, etc.) are always documents and need no prompt.
+        """
+        bp_exts = [e.lower() for e in self.app_context.get_setting('blueprint_extensions', ['.pdf', '.dwg', '.dxf'])]
         for path in list(newly_added):
+            if Path(path).suffix.lower() not in bp_exts:
+                continue
             is_flagged, reason = classify_document(path)
             if not is_flagged:
                 continue

--- a/modules/quote/module.py
+++ b/modules/quote/module.py
@@ -303,10 +303,14 @@ class QuoteModule(BaseModule):
         if self.quote_files_list is None:
             return
 
+        newly_added = []
         for file in files:
             if file not in self.quote_files:
                 self.quote_files.append(file)
                 self.quote_files_list.addItem(os.path.basename(file))
+                newly_added.append(file)
+        if newly_added:
+            self._check_po_rfq_files(newly_added, self.quote_files, self.quote_files_list)
 
     def remove_quote_file(self):
         """Remove selected file from quote files list (Create New tab)"""
@@ -526,13 +530,17 @@ class QuoteModule(BaseModule):
             selected_files = dialog.get_selected_files()
             if selected_files:
                 files_added = 0
+                newly_added = []
                 for file_path in selected_files:
                     if file_path not in self.quote_files:
                         self.quote_files.append(file_path)
                         self.quote_files_list.addItem(os.path.basename(file_path))
                         files_added += 1
+                        newly_added.append(file_path)
                 if files_added > 0:
                     self.log_message(f"Linked {files_added} drawing(s)")
+                if newly_added:
+                    self._check_po_rfq_files(newly_added, self.quote_files, self.quote_files_list)
 
     def _copy_info_from_folder(self, folder_path: str):
         """Copy job/quote info from folder to form, including optional file copy"""
@@ -727,10 +735,14 @@ class QuoteModule(BaseModule):
 
     def handle_add_files(self, files: List[str]):
         """Add files to the add files list (Add to Existing tab)"""
+        newly_added = []
         for f in files:
             if f not in self.add_files:
                 self.add_files.append(f)
                 self.add_files_list.addItem(os.path.basename(f))
+                newly_added.append(f)
+        if newly_added:
+            self._check_po_rfq_files(newly_added, self.add_files, self.add_files_list)
 
     def remove_add_file(self):
         """Remove selected file from add files list"""

--- a/shared/utils.py
+++ b/shared/utils.py
@@ -10,6 +10,7 @@ import platform
 import shutil
 import re
 import subprocess
+from collections import OrderedDict
 from pathlib import Path
 from typing import Dict, Any, List, Tuple, Optional
 
@@ -107,7 +108,8 @@ _PO_RFQ_TEXT_RE = re.compile(
 )
 
 
-_classify_cache: Dict[str, Tuple[float, bool, str]] = {}  # path -> (mtime, flagged, reason)
+_MAX_CLASSIFY_CACHE = 500
+_classify_cache: OrderedDict[str, Tuple[float, bool, str]] = OrderedDict()  # path -> (mtime, flagged, reason)
 
 
 def classify_document(filepath: str) -> Tuple[bool, str]:
@@ -128,6 +130,9 @@ def classify_document(filepath: str) -> Tuple[bool, str]:
     flagged, reason = _classify_document_uncached(filepath)
     try:
         _classify_cache[filepath] = (os.path.getmtime(filepath), flagged, reason)
+        _classify_cache.move_to_end(filepath)
+        if len(_classify_cache) > _MAX_CLASSIFY_CACHE:
+            _classify_cache.popitem(last=False)
     except OSError:
         pass
     return flagged, reason

--- a/shared/utils.py
+++ b/shared/utils.py
@@ -92,6 +92,46 @@ def get_os_text(key: str) -> str:
     return ""
 
 
+_PO_RFQ_NAME_RE = re.compile(
+    r'(?<![A-Za-z])p\.?o\.?(?![A-Za-z])'
+    r'|purchase[\s_\-]?order'
+    r'|(?<![A-Za-z])rfq(?![A-Za-z])'
+    r'|request[\s_\-]?for[\s_\-]?quote',
+    re.IGNORECASE,
+)
+
+_PO_RFQ_TEXT_RE = re.compile(
+    r'purchase\s+order|p\.?o\.?\s*(?:#|number|num|no\.?)'
+    r'|request\s+for\s+quote|rfq\s*(?:#|number|num|no\.?)',
+    re.IGNORECASE,
+)
+
+
+def classify_document(filepath: str) -> Tuple[bool, str]:
+    """
+    Detect if a file is likely a PO or RFQ.
+    Checks filename first, then first-page PDF text when PyMuPDF is available.
+    Returns (is_po_rfq, reason).
+    """
+    stem = os.path.splitext(os.path.basename(filepath))[0]
+    if _PO_RFQ_NAME_RE.search(stem):
+        return True, "filename contains PO/RFQ keyword"
+
+    if filepath.lower().endswith('.pdf'):
+        try:
+            import fitz  # PyMuPDF
+            doc = fitz.open(filepath)
+            try:
+                if doc.page_count > 0 and _PO_RFQ_TEXT_RE.search(doc[0].get_text()):
+                    return True, "PDF content contains PO/RFQ keyword"
+            finally:
+                doc.close()
+        except Exception:
+            pass
+
+    return False, ""
+
+
 def is_blueprint_file(filename: str, blueprint_extensions: List[str]) -> bool:
     """
     Check if a file is a blueprint based on its extension.

--- a/shared/utils.py
+++ b/shared/utils.py
@@ -107,12 +107,33 @@ _PO_RFQ_TEXT_RE = re.compile(
 )
 
 
+_classify_cache: Dict[str, Tuple[float, bool, str]] = {}  # path -> (mtime, flagged, reason)
+
+
 def classify_document(filepath: str) -> Tuple[bool, str]:
     """
     Detect if a file is likely a PO or RFQ.
     Checks filename first, then first-page PDF text when PyMuPDF is available.
+    Results are cached by file path and mtime to avoid blocking repeated searches.
     Returns (is_po_rfq, reason).
     """
+    try:
+        mtime = os.path.getmtime(filepath)
+        cached = _classify_cache.get(filepath)
+        if cached and cached[0] == mtime:
+            return cached[1], cached[2]
+    except OSError:
+        pass
+
+    flagged, reason = _classify_document_uncached(filepath)
+    try:
+        _classify_cache[filepath] = (os.path.getmtime(filepath), flagged, reason)
+    except OSError:
+        pass
+    return flagged, reason
+
+
+def _classify_document_uncached(filepath: str) -> Tuple[bool, str]:
     stem = os.path.splitext(os.path.basename(filepath))[0]
     if _PO_RFQ_NAME_RE.search(stem):
         return True, "filename contains PO/RFQ keyword"
@@ -126,8 +147,8 @@ def classify_document(filepath: str) -> Tuple[bool, str]:
                     return True, "PDF content contains PO/RFQ keyword"
             finally:
                 doc.close()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("classify_document: could not read PDF '%s': %s", filepath, e)
 
     return False, ""
 

--- a/shared/widgets.py
+++ b/shared/widgets.py
@@ -11,7 +11,7 @@ from PyQt6.QtWidgets import (
     QWidget, QSplitter, QSizePolicy
 )
 from PyQt6.QtCore import Qt, pyqtSignal, QObject, pyqtSlot, QSize, QThread
-from PyQt6.QtGui import QDragEnterEvent, QDropEvent, QImage, QPixmap
+from PyQt6.QtGui import QBrush, QColor, QDragEnterEvent, QDropEvent, QImage, QPixmap
 from pathlib import Path
 import atexit
 import logging
@@ -1206,14 +1206,22 @@ class DrawingSearchDialog(QDialog):
                 pass
 
         # Add results to tree (limit to 200)
+        from shared.utils import classify_document
+        _orange = QColor(200, 120, 0)
         for filename, location, file_type, full_path in sorted(results)[:200]:
+            is_po_rfq, flag_reason = classify_document(full_path)
             item = QTreeWidgetItem()
             item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
             item.setCheckState(0, Qt.CheckState.Unchecked)
             item.setText(0, filename)
             item.setText(1, location)
-            item.setText(2, file_type)
+            item.setText(2, "⚠ PO/RFQ" if is_po_rfq else file_type)
             item.setData(0, Qt.ItemDataRole.UserRole, full_path)
+            if is_po_rfq:
+                brush = QBrush(_orange)
+                for col in range(3):
+                    item.setForeground(col, brush)
+                item.setToolTip(0, f"Flagged as PO/RFQ: {flag_reason}")
             self.results_tree.addTopLevelItem(item)
 
         if results:

--- a/shared/widgets.py
+++ b/shared/widgets.py
@@ -1222,6 +1222,7 @@ class DrawingSearchDialog(QDialog):
                 for col in range(3):
                     item.setForeground(col, brush)
                 item.setToolTip(0, f"Flagged as PO/RFQ: {flag_reason}")
+                item.setData(0, Qt.ItemDataRole.UserRole + 1, True)  # flagged_po_rfq
             self.results_tree.addTopLevelItem(item)
 
         if results:
@@ -1230,10 +1231,11 @@ class DrawingSearchDialog(QDialog):
             self.status_label.setText("No matches found")
 
     def _select_all(self):
-        """Select all files"""
+        """Select all non-flagged files"""
         for i in range(self.results_tree.topLevelItemCount()):
             item = self.results_tree.topLevelItem(i)
-            item.setCheckState(0, Qt.CheckState.Checked)
+            if not item.data(0, Qt.ItemDataRole.UserRole + 1):
+                item.setCheckState(0, Qt.CheckState.Checked)
 
     def _select_none(self):
         """Deselect all files"""


### PR DESCRIPTION
## Summary
- Adds `classify_document()` to `shared/utils.py` — checks filename patterns first (`PO`, `P.O.`, `RFQ`, `purchase order`, `request for quote`), then extracts first-page text from PDFs via PyMuPDF if available
- `DrawingSearchDialog` now renders PO/RFQ matches in orange with a `⚠ PO/RFQ` type label and tooltip; they stay unchecked by default so they don't accidentally get linked as drawings
- All three file-add entry points in the Job module (Create New drop zone, Link Drawings dialog, Add to Existing drop zone) now call `_check_po_rfq_files()` after adding files — showing a warning dialog with **Save as Document** / **Remove** buttons for each flagged file

## Test plan
- [x] Drop a file named `PO12345.pdf` onto the Create New drop zone — expect PO/RFQ dialog
- [x] Drop a file named `RFQ-2024.pdf` — expect PO/RFQ dialog
- [x] Drop a regular drawing PDF — expect no dialog
- [x] Search for a drawing number in Link Drawings dialog where blueprints dir contains a `PO_something.pdf` — expect orange flagged row
- [x] Select the flagged row and click OK — expect PO/RFQ dialog with Save as Document / Remove options
- [x] Confirm "Remove" removes the file from the list; confirm "Save as Document" keeps it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Files added (new or existing) are auto-scanned for PO/RFQ indicators; flagged files show a modal with the reason and can be removed from the list.
  * Drawing search results display a ⚠ PO/RFQ label, orange styling, and a tooltip; "Select All" skips flagged items.

* **Behavior**
  * Classification checks filename and first-page PDF text when available and caches results to avoid repeated work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->