### PR TITLE
feat: in-app update download and install

### DIFF
--- a/main.py
+++ b/main.py
@@ -212,7 +212,8 @@ class _UpdateDialog(QDialog):
             self.accept()
 
     def _start_download(self) -> None:
-        fd, dest = tempfile.mkstemp(suffix=".exe", prefix=f"JobDocs-{self._latest_version}-")
+        safe_ver = ''.join(c if c.isalnum() or c in '._-' else '_' for c in self._latest_version)
+        fd, dest = tempfile.mkstemp(suffix=".exe", prefix=f"JobDocs-{safe_ver}-")
         os.close(fd)
 
         progress_dlg = QProgressDialog(
@@ -225,11 +226,9 @@ class _UpdateDialog(QDialog):
 
         downloader = _UpdateDownloader(self._asset_url, dest)
         self._downloader = downloader
+        progress_dlg.canceled.connect(downloader.requestInterruption)
 
         def _on_progress(done: int, total: int) -> None:
-            if progress_dlg.wasCanceled():
-                downloader.requestInterruption()
-                return
             progress_dlg.setValue(int(done * 100 / total) if total else 50)
 
         def _on_done(path: str) -> None:

--- a/main.py
+++ b/main.py
@@ -101,6 +101,7 @@ class _UpdateDownloader(QThread):
     """Downloads a release asset to a temp file on a background thread."""
     progress = pyqtSignal(int, int)  # (bytes_done, total_bytes)
     finished = pyqtSignal(str)       # dest_path on success
+    cancelled = pyqtSignal()
     error = pyqtSignal(str)
 
     def __init__(self, asset_url: str, dest_path: str):
@@ -134,7 +135,7 @@ class _UpdateDownloader(QThread):
                     os.remove(self._dest_path)
                 except OSError:
                     pass
-                self.error.emit("cancelled")
+                self.cancelled.emit()
                 return
             self.finished.emit(self._dest_path)
         except Exception as exc:
@@ -200,7 +201,8 @@ class _UpdateDialog(QDialog):
             self.accept()
 
     def _start_download(self) -> None:
-        dest = os.path.join(tempfile.gettempdir(), f"JobDocs-{self._latest_version}-Setup.exe")
+        fd, dest = tempfile.mkstemp(suffix=".exe", prefix=f"JobDocs-{self._latest_version}-")
+        os.close(fd)
 
         progress_dlg = QProgressDialog(
             f"Downloading {self._latest_version}...", "Cancel", 0, 100, self,
@@ -221,6 +223,24 @@ class _UpdateDialog(QDialog):
 
         def _on_done(path: str) -> None:
             progress_dlg.close()
+            try:
+                with open(path, 'rb') as _f:
+                    if _f.read(2) != b'MZ':
+                        raise ValueError("Not a valid Windows executable (bad PE header)")
+            except (OSError, ValueError) as exc:
+                QMessageBox.critical(
+                    self, "Verification Failed",
+                    f"The downloaded installer failed verification:\n{exc}\n\n"
+                    "Opening the releases page instead.",
+                )
+                try:
+                    os.remove(path)
+                except OSError:
+                    pass
+                import webbrowser
+                webbrowser.open(self._release_url)
+                self.accept()
+                return
             reply = QMessageBox.question(
                 self, "Ready to Install",
                 f"{self._latest_version} downloaded.\n\n"
@@ -240,6 +260,9 @@ class _UpdateDialog(QDialog):
                 QApplication.quit()
             self.accept()
 
+        def _on_cancelled() -> None:
+            progress_dlg.close()
+
         def _on_error(msg: str) -> None:
             progress_dlg.close()
             QMessageBox.warning(
@@ -252,8 +275,10 @@ class _UpdateDialog(QDialog):
 
         downloader.progress.connect(_on_progress)
         downloader.finished.connect(_on_done)
+        downloader.cancelled.connect(_on_cancelled)
         downloader.error.connect(_on_error)
         downloader.finished.connect(downloader.deleteLater)
+        downloader.cancelled.connect(downloader.deleteLater)
         downloader.error.connect(downloader.deleteLater)
         downloader.start()
 

--- a/main.py
+++ b/main.py
@@ -137,8 +137,19 @@ class _UpdateDownloader(QThread):
                     pass
                 self.cancelled.emit()
                 return
+            if total > 0 and done != total:
+                try:
+                    os.remove(self._dest_path)
+                except OSError:
+                    pass
+                self.error.emit(f"Download truncated: received {done} of {total} bytes")
+                return
             self.finished.emit(self._dest_path)
         except Exception as exc:
+            try:
+                os.remove(self._dest_path)
+            except OSError:
+                pass
             self.error.emit(str(exc))
 
 

--- a/main.py
+++ b/main.py
@@ -70,7 +70,7 @@ def _version_tuple(v: str) -> tuple:
 
 class _UpdateChecker(QThread):
     """Queries the GitHub releases API on a background thread."""
-    update_available = pyqtSignal(str, str)  # (tag, html_url)
+    update_available = pyqtSignal(str, str, str)  # (tag, html_url, asset_url)
     up_to_date = pyqtSignal()
 
     def run(self):
@@ -85,30 +85,73 @@ class _UpdateChecker(QThread):
             tag = data.get("tag_name", "")
             html_url = data.get("html_url", "")
             if tag and _version_tuple(tag) > _version_tuple(APP_VERSION):
-                self.update_available.emit(tag, html_url)
+                asset_url = ""
+                for asset in data.get("assets", []):
+                    if asset.get("name", "").lower().endswith(".exe"):
+                        asset_url = asset.get("browser_download_url", "")
+                        break
+                self.update_available.emit(tag, html_url, asset_url)
             else:
                 self.up_to_date.emit()
         except (urllib.error.URLError, OSError, json.JSONDecodeError, ValueError):
             pass
 
 
+class _UpdateDownloader(QThread):
+    """Downloads a release asset to a temp file on a background thread."""
+    progress = pyqtSignal(int, int)  # (bytes_done, total_bytes)
+    finished = pyqtSignal(str)       # dest_path on success
+    error = pyqtSignal(str)
+
+    def __init__(self, asset_url: str, dest_path: str):
+        super().__init__()
+        self._asset_url = asset_url
+        self._dest_path = dest_path
+
+    def run(self):
+        try:
+            req = urllib.request.Request(
+                self._asset_url,
+                headers={"User-Agent": "JobDocs"},
+            )
+            with urllib.request.urlopen(req, timeout=60) as resp:  # nosec B310
+                total = int(resp.headers.get("Content-Length", 0))
+                done = 0
+                with open(self._dest_path, "wb") as f:
+                    while True:
+                        if self.isInterruptionRequested():
+                            return
+                        buf = resp.read(65536)
+                        if not buf:
+                            break
+                        f.write(buf)
+                        done += len(buf)
+                        self.progress.emit(done, total)
+            self.finished.emit(self._dest_path)
+        except Exception as exc:
+            self.error.emit(str(exc))
+
+
 class _UpdateDialog(QDialog):
     """Non-blocking update-available prompt."""
 
-    def __init__(self, latest_version: str, release_url: str, app_context, parent=None):
+    def __init__(self, latest_version: str, release_url: str, asset_url: str, app_context, parent=None):
         super().__init__(parent)
         self.setWindowTitle("Update Available")
         self.setMinimumWidth(340)
         self._app_context = app_context
         self._latest_version = latest_version
         self._release_url = release_url
+        self._asset_url = asset_url
+
+        import platform as _platform
+        self._is_flatpak = _platform.system() == 'Linux' and bool(os.getenv('FLATPAK_ID'))
+        self._can_download = _platform.system() == 'Windows' and bool(asset_url)
 
         layout = QVBoxLayout(self)
 
         import html as _html
-        label = QLabel(
-            f"<b>{_html.escape(latest_version)}</b> is available. Upgrade now?"
-        )
+        label = QLabel(f"<b>{_html.escape(latest_version)}</b> is available. Upgrade now?")
         label.setTextFormat(Qt.TextFormat.RichText)
         layout.addWidget(label)
 
@@ -116,7 +159,8 @@ class _UpdateDialog(QDialog):
         layout.addWidget(self._disable_cb)
 
         buttons = QDialogButtonBox()
-        buttons.addButton("Update Now", QDialogButtonBox.ButtonRole.AcceptRole)
+        ok_label = "Download & Install" if self._can_download else "Update Now"
+        buttons.addButton(ok_label, QDialogButtonBox.ButtonRole.AcceptRole)
         buttons.addButton("Skip This Version", QDialogButtonBox.ButtonRole.RejectRole)
         buttons.accepted.connect(self._on_ok)
         buttons.rejected.connect(self._on_later)
@@ -129,19 +173,72 @@ class _UpdateDialog(QDialog):
 
     def _on_ok(self) -> None:
         self._save_disabled()
-        import platform
-        import webbrowser
-        if platform.system() == 'Linux' and os.getenv('FLATPAK_ID'):
+        if self._is_flatpak:
             try:
                 subprocess.Popen(
                     ['flatpak-spawn', '--host', 'xdg-open',
                      'appstream://io.github.i_machine_things.JobDocs'],
                 )
             except Exception:
+                import webbrowser
                 webbrowser.open(self._release_url)
+            self.accept()
+        elif self._can_download:
+            self._start_download()
         else:
+            import webbrowser
             webbrowser.open(self._release_url)
-        self.accept()
+            self.accept()
+
+    def _start_download(self) -> None:
+        dest = os.path.join(tempfile.gettempdir(), f"JobDocs-{self._latest_version}-Setup.exe")
+
+        progress_dlg = QProgressDialog(
+            f"Downloading {self._latest_version}...", "Cancel", 0, 100, self,
+        )
+        progress_dlg.setWindowTitle("Downloading Update")
+        progress_dlg.setWindowModality(Qt.WindowModality.WindowModal)
+        progress_dlg.setMinimumDuration(0)
+        progress_dlg.setValue(0)
+
+        downloader = _UpdateDownloader(self._asset_url, dest)
+        self._downloader = downloader
+
+        def _on_progress(done: int, total: int) -> None:
+            if progress_dlg.wasCanceled():
+                downloader.requestInterruption()
+                return
+            progress_dlg.setValue(int(done * 100 / total) if total else 50)
+
+        def _on_done(path: str) -> None:
+            progress_dlg.close()
+            reply = QMessageBox.question(
+                self, "Ready to Install",
+                f"{self._latest_version} downloaded.\n\n"
+                "JobDocs will close and the installer will launch.\nReady to install?",
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            )
+            if reply == QMessageBox.StandardButton.Yes:
+                subprocess.Popen([path])
+                QApplication.quit()
+            self.accept()
+
+        def _on_error(msg: str) -> None:
+            progress_dlg.close()
+            QMessageBox.warning(
+                self, "Download Failed",
+                f"Could not download the update:\n{msg}\n\nOpening the releases page instead.",
+            )
+            import webbrowser
+            webbrowser.open(self._release_url)
+            self.accept()
+
+        downloader.progress.connect(_on_progress)
+        downloader.finished.connect(_on_done)
+        downloader.error.connect(_on_error)
+        downloader.finished.connect(downloader.deleteLater)
+        downloader.error.connect(downloader.deleteLater)
+        downloader.start()
 
     def _on_later(self) -> None:
         self._save_disabled()
@@ -1112,8 +1209,8 @@ near-instant even across thousands of jobs.</p>""",
         if existing is not None and existing.isRunning():
             return
 
-        def _on_available(tag: str, url: str) -> None:
-            dlg = _UpdateDialog(tag, url, self.app_context, self)
+        def _on_available(tag: str, url: str, asset_url: str) -> None:
+            dlg = _UpdateDialog(tag, url, asset_url, self.app_context, self)
             self._manual_update_dialog = dlg  # type: ignore[attr-defined]
             dlg.finished.connect(lambda _: setattr(self, '_manual_update_dialog', None))
             dlg.show()
@@ -1316,10 +1413,10 @@ def main():
     window = JobDocsMainWindow()
     window.show()
 
-    def _on_update_available(tag: str, url: str) -> None:
+    def _on_update_available(tag: str, url: str, asset_url: str) -> None:
         if window.app_context.get_setting('updates_notifications_disabled', False):
             return
-        dlg = _UpdateDialog(tag, url, window.app_context, window)
+        dlg = _UpdateDialog(tag, url, asset_url, window.app_context, window)
         window._update_dialog = dlg  # type: ignore[attr-defined]
         dlg.finished.connect(lambda _: setattr(window, '_update_dialog', None))
         dlg.show()

--- a/main.py
+++ b/main.py
@@ -111,6 +111,9 @@ class _UpdateDownloader(QThread):
 
     def run(self):
         try:
+            if not self._asset_url.startswith("https://"):
+                self.error.emit("Invalid asset URL scheme")
+                return
             req = urllib.request.Request(
                 self._asset_url,
                 headers={"User-Agent": "JobDocs"},

--- a/main.py
+++ b/main.py
@@ -114,19 +114,28 @@ class _UpdateDownloader(QThread):
                 self._asset_url,
                 headers={"User-Agent": "JobDocs"},
             )
+            cancelled = False
             with urllib.request.urlopen(req, timeout=60) as resp:  # nosec B310
                 total = int(resp.headers.get("Content-Length", 0))
                 done = 0
                 with open(self._dest_path, "wb") as f:
                     while True:
                         if self.isInterruptionRequested():
-                            return
+                            cancelled = True
+                            break
                         buf = resp.read(65536)
                         if not buf:
                             break
                         f.write(buf)
                         done += len(buf)
                         self.progress.emit(done, total)
+            if cancelled:
+                try:
+                    os.remove(self._dest_path)
+                except OSError:
+                    pass
+                self.error.emit("cancelled")
+                return
             self.finished.emit(self._dest_path)
         except Exception as exc:
             self.error.emit(str(exc))
@@ -219,7 +228,15 @@ class _UpdateDialog(QDialog):
                 QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
             )
             if reply == QMessageBox.StandardButton.Yes:
-                subprocess.Popen([path])
+                try:
+                    subprocess.Popen([path])
+                except OSError as exc:
+                    QMessageBox.critical(
+                        self, "Launch Failed",
+                        f"Could not launch the installer:\n{exc}\n\nInstaller saved at:\n{path}",
+                    )
+                    self.accept()
+                    return
                 QApplication.quit()
             self.accept()
 

--- a/main.py
+++ b/main.py
@@ -180,7 +180,7 @@ class _UpdateDialog(QDialog):
         layout.addWidget(self._disable_cb)
 
         buttons = QDialogButtonBox()
-        ok_label = "Download & Install" if self._can_download else "Update Now"
+        ok_label = "Download && Install" if self._can_download else "Update Now"
         buttons.addButton(ok_label, QDialogButtonBox.ButtonRole.AcceptRole)
         buttons.addButton("Skip This Version", QDialogButtonBox.ButtonRole.RejectRole)
         buttons.accepted.connect(self._on_ok)
@@ -295,6 +295,9 @@ class _UpdateDialog(QDialog):
 
     def _on_later(self) -> None:
         self._save_disabled()
+        if self._app_context is not None:
+            self._app_context.set_setting('updates_skipped_version', self._latest_version)
+            self._app_context.save_settings()
         self.reject()
 
 
@@ -1468,6 +1471,8 @@ def main():
 
     def _on_update_available(tag: str, url: str, asset_url: str) -> None:
         if window.app_context.get_setting('updates_notifications_disabled', False):
+            return
+        if window.app_context.get_setting('updates_skipped_version', '') == tag:
             return
         dlg = _UpdateDialog(tag, url, asset_url, window.app_context, window)
         window._update_dialog = dlg  # type: ignore[attr-defined]

--- a/modules/search/module.py
+++ b/modules/search/module.py
@@ -114,7 +114,8 @@ class SearchWorker(QThread):
                 customer_match = self.search_customer and self.search_term in customer.lower()
 
                 # Find job folders
-                jobs = self.app_context.find_job_folders(customer_path)
+                scan_errors: List[OSError] = []
+                jobs = self.app_context.find_job_folders(customer_path, errors=scan_errors)
 
                 for dir_name, job_docs_path in jobs:
                     if self._is_cancelled:
@@ -158,10 +159,10 @@ class SearchWorker(QThread):
                         self.result_count += 1
 
                 # find_job_folders requires a specific subfolder (e.g. "job documents")
-                # that may not exist.  When the customer name matched but no structured
-                # jobs were returned, fall back to a plain directory scan so the customer
-                # is still reachable in strict mode.
-                if customer_match and not jobs:
+                # that may not exist.  Fall back to a plain digit-prefixed directory scan
+                # whenever no structured jobs were returned, applying the same match logic
+                # so searches by job number or description still work on flat layouts.
+                if not jobs and not scan_errors:
                     try:
                         for item in sorted(os.listdir(customer_path)):
                             if self._is_cancelled:
@@ -170,6 +171,17 @@ class SearchWorker(QThread):
                             if not os.path.isdir(item_path) or not item or not item[0].isdigit():
                                 continue
                             job_num, desc, drawings = _parse_job_folder(item)
+                            match = customer_match
+                            if not match and self.search_job and self.search_term in job_num.lower():
+                                match = True
+                            if not match and self.search_desc and self.search_term in desc.lower():
+                                match = True
+                            if not match and self.search_drawing and any(
+                                self.search_term in d.lower() for d in drawings
+                            ):
+                                match = True
+                            if not match:
+                                continue
                             try:
                                 mod_time = datetime.fromtimestamp(Path(item_path).stat().st_mtime)
                             except OSError:
@@ -396,11 +408,11 @@ class SearchModule(BaseModule):
         self._index_worker.start()
 
     def _on_index_progress(self, msg: str):
-        if self.search_status_label:
+        if self.search_status_label and not (self._worker and self._worker.isRunning()):
             self.search_status_label.setText(f"Index: {msg}")
 
     def _on_index_finished(self, job_count: int):
-        if self.search_status_label:
+        if self.search_status_label and not (self._worker and self._worker.isRunning()):
             self.search_status_label.setText(f"Index ready — {job_count} jobs")
 
     def get_widget(self) -> QWidget:


### PR DESCRIPTION
## Summary
- On Windows, the update dialog now shows **Download & Install** instead of opening the GitHub releases page
- `_UpdateDownloader` (QThread) fetches the `.exe` asset from GitHub releases to a temp file with a cancellable progress bar
- On completion the user confirms, the installer launches via `subprocess.Popen`, and JobDocs exits — Inno Setup takes over
- Cancellation deletes the partial temp file and emits a terminal error signal
- Installer launch failure is caught with `OSError`, shows a critical dialog, and does **not** quit the app
- Download failure falls back to opening the releases page in the browser
- Index progress/finished signals no longer overwrite the status label during an active search
- Linux/Flatpak behaviour unchanged (appstream URI or browser fallback)

## Test plan
- [ ] Trigger update check with a release that has a `.exe` asset — confirm "Download & Install" button appears
- [ ] Complete download — confirm progress bar advances and installer launches on confirm
- [ ] Cancel mid-download — confirm no partial file remains and app stays open
- [ ] Simulate download error — confirm fallback to browser opens correctly
- [ ] Simulate failed installer launch — confirm error dialog shows, app stays open
- [ ] Run index while searching — confirm "Searching…" status is not clobbered by index progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Update checker now finds platform installer assets; Windows can download installers with progress, cancellation, a basic integrity check, and prompts before running. Flatpak opens the app store when available.
  * “Skip This Version” is saved; startup checks honor skipped versions to suppress prompts.
  * Manual and automatic update checks provide installer URLs when available.

* **Bug Fixes**
  * Index progress messages no longer overwrite live search status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->