### PR TITLE
feat: include quotes in search results

### DIFF
--- a/core/search_index.py
+++ b/core/search_index.py
@@ -545,10 +545,13 @@ class SearchIndex:
 
                             # Index quotes for this customer.
                             new_quote_rows = []
+                            quote_scan_cancelled = False
+                            quote_scan_failed = False
                             if os.path.isdir(quotes_dir):
                                 try:
                                     for item in os.listdir(quotes_dir):
                                         if _cancelled():
+                                            quote_scan_cancelled = True
                                             break
                                         item_path = os.path.join(quotes_dir, item)
                                         if not os.path.isdir(item_path):
@@ -561,19 +564,21 @@ class SearchIndex:
                                             (prefix, customer, item, item_path, mtime)
                                         )
                                 except OSError as exc:
+                                    quote_scan_failed = True
                                     logger.warning(
                                         "search_index: quote scan(%s): %s", quotes_dir, exc
                                     )
-                            conn.execute(
-                                "DELETE FROM quotes WHERE customer=? AND prefix=?",
-                                (customer, prefix),
-                            )
-                            conn.executemany(
-                                """INSERT OR REPLACE INTO quotes
-                                   (prefix, customer, quote_name, path, mtime)
-                                   VALUES(?,?,?,?,?)""",
-                                new_quote_rows,
-                            )
+                            if not quote_scan_cancelled and not quote_scan_failed:
+                                conn.execute(
+                                    "DELETE FROM quotes WHERE customer=? AND prefix=?",
+                                    (customer, prefix),
+                                )
+                                conn.executemany(
+                                    """INSERT OR REPLACE INTO quotes
+                                       (prefix, customer, quote_name, path, mtime)
+                                       VALUES(?,?,?,?,?)""",
+                                    new_quote_rows,
+                                )
 
                             for d in container_dirs:
                                 self._mark_indexed(conn, d, prefix, 'cf')

--- a/core/search_index.py
+++ b/core/search_index.py
@@ -580,7 +580,12 @@ class SearchIndex:
                                     new_quote_rows,
                                 )
 
-                            for d in container_dirs:
+                            # Skip marking quotes_dir indexed if its scan failed
+                            # or was cancelled so the next launch will retry it.
+                            dirs_to_mark = container_dirs.copy()
+                            if quote_scan_cancelled or quote_scan_failed:
+                                dirs_to_mark.discard(quotes_dir)
+                            for d in dirs_to_mark:
                                 self._mark_indexed(conn, d, prefix, 'cf')
 
                             # Prune indexed_dirs rows for containers that no longer

--- a/core/search_index.py
+++ b/core/search_index.py
@@ -43,6 +43,16 @@ CREATE TABLE IF NOT EXISTS bp_files (
     UNIQUE(prefix, dir_path, filename)
 );
 
+CREATE TABLE IF NOT EXISTS quotes (
+    id          INTEGER PRIMARY KEY,
+    prefix      TEXT    NOT NULL DEFAULT '',
+    customer    TEXT    NOT NULL,
+    quote_name  TEXT    NOT NULL DEFAULT '',
+    path        TEXT    NOT NULL,
+    mtime       REAL    NOT NULL,
+    UNIQUE(prefix, path)
+);
+
 CREATE TABLE IF NOT EXISTS indexed_dirs (
     dir_path    TEXT    NOT NULL,
     prefix      TEXT    NOT NULL DEFAULT '',
@@ -59,6 +69,8 @@ CREATE INDEX IF NOT EXISTS idx_jobs_draw        ON jobs(drawings    COLLATE NOCA
 CREATE INDEX IF NOT EXISTS idx_jobs_cust_prefix ON jobs(customer, prefix);
 CREATE INDEX IF NOT EXISTS idx_bp_filename      ON bp_files(filename COLLATE NOCASE);
 CREATE INDEX IF NOT EXISTS idx_bp_cust          ON bp_files(customer COLLATE NOCASE);
+CREATE INDEX IF NOT EXISTS idx_quotes_name      ON quotes(quote_name COLLATE NOCASE);
+CREATE INDEX IF NOT EXISTS idx_quotes_cust      ON quotes(customer   COLLATE NOCASE);
 """
 
 _MIGRATION_V1 = """
@@ -121,6 +133,13 @@ CREATE TABLE indexed_dirs (
     PRIMARY KEY (dir_path, prefix, kind)
 );
 PRAGMA user_version = 2;
+COMMIT;
+"""
+
+_MIGRATION_V3 = """
+BEGIN;
+DELETE FROM indexed_dirs WHERE kind='cf';
+PRAGMA user_version = 3;
 COMMIT;
 """
 
@@ -207,7 +226,7 @@ class SearchIndex:
 
     def _migrate(self, conn: sqlite3.Connection) -> None:
         version = conn.execute("PRAGMA user_version").fetchone()[0]
-        if version >= 2:
+        if version >= 3:
             return
         if version < 1:
             row = conn.execute(
@@ -218,8 +237,11 @@ class SearchIndex:
                 conn.executescript(_MIGRATION_V1)
             else:
                 conn.execute("PRAGMA user_version = 1")
-        logger.info("search_index: migrating schema to v2 (kind-aware indexed_dirs)")
-        conn.executescript(_MIGRATION_V2)
+        if version < 2:
+            logger.info("search_index: migrating schema to v2 (kind-aware indexed_dirs)")
+            conn.executescript(_MIGRATION_V2)
+        logger.info("search_index: migrating schema to v3 (quotes table, force re-index)")
+        conn.executescript(_MIGRATION_V3)
 
     def _dir_mtime(self, path: str) -> float:
         try:
@@ -352,9 +374,14 @@ class SearchIndex:
                         f"DELETE FROM indexed_dirs WHERE kind='cf' AND prefix NOT IN ({_ph})",  # nosec B608  # noqa: S608, E501
                         tuple(all_cf_prefixes),
                     )
+                    conn.execute(
+                        f"DELETE FROM quotes WHERE prefix NOT IN ({_ph})",  # nosec B608  # noqa: S608
+                        tuple(all_cf_prefixes),
+                    )
                 else:
                     conn.execute("DELETE FROM jobs")
                     conn.execute("DELETE FROM indexed_dirs WHERE kind='cf'")
+                    conn.execute("DELETE FROM quotes")
 
                 if all_bp_prefixes:
                     _ph = ','.join('?' * len(all_bp_prefixes))
@@ -391,8 +418,13 @@ class SearchIndex:
                                 f"DELETE FROM jobs WHERE prefix=? AND customer NOT IN ({placeholders})",  # nosec B608  # noqa: S608, E501
                                 (prefix, *customer_set),
                             )
+                            conn.execute(
+                                f"DELETE FROM quotes WHERE prefix=? AND customer NOT IN ({placeholders})",  # nosec B608  # noqa: S608, E501
+                                (prefix, *customer_set),
+                            )
                         else:
                             conn.execute("DELETE FROM jobs WHERE prefix=?", (prefix,))
+                            conn.execute("DELETE FROM quotes WHERE prefix=?", (prefix,))
 
                     for customer in customers:
                         if _cancelled():
@@ -433,6 +465,8 @@ class SearchIndex:
                         # in indexed_dirs. customer_path must be included so the
                         # precheck can confirm it was indexed and avoid calling
                         # find_job_folders every run.
+                        # Also track the quotes dir so a new quote folder triggers
+                        # re-indexing even when no job folders changed.
                         customer_p = Path(customer_path)
                         container_dirs: set = {customer_path}
                         for _, job_docs_path in jobs:
@@ -440,6 +474,10 @@ class SearchIndex:
                                 if p == customer_p:
                                     break
                                 container_dirs.add(str(p))
+                        quote_folder_path = app_context.get_setting('quote_folder_path', 'Quotes')
+                        quotes_dir = os.path.join(customer_path, quote_folder_path)
+                        if os.path.isdir(quotes_dir):
+                            container_dirs.add(quotes_dir)
                         all_containers = container_dirs | prev_containers
 
                         if not any(self._is_stale(conn, d, prefix, 'cf') for d in all_containers):
@@ -504,6 +542,39 @@ class SearchIndex:
                                    VALUES(?,?,?,?,?,?,?)""",
                                 new_job_rows,
                             )
+
+                            # Index quotes for this customer.
+                            new_quote_rows = []
+                            if os.path.isdir(quotes_dir):
+                                try:
+                                    for item in os.listdir(quotes_dir):
+                                        if _cancelled():
+                                            break
+                                        item_path = os.path.join(quotes_dir, item)
+                                        if not os.path.isdir(item_path):
+                                            continue
+                                        try:
+                                            mtime = os.path.getmtime(item_path)
+                                        except OSError:
+                                            continue
+                                        new_quote_rows.append(
+                                            (prefix, customer, item, item_path, mtime)
+                                        )
+                                except OSError as exc:
+                                    logger.warning(
+                                        "search_index: quote scan(%s): %s", quotes_dir, exc
+                                    )
+                            conn.execute(
+                                "DELETE FROM quotes WHERE customer=? AND prefix=?",
+                                (customer, prefix),
+                            )
+                            conn.executemany(
+                                """INSERT OR REPLACE INTO quotes
+                                   (prefix, customer, quote_name, path, mtime)
+                                   VALUES(?,?,?,?,?)""",
+                                new_quote_rows,
+                            )
+
                             for d in container_dirs:
                                 self._mark_indexed(conn, d, prefix, 'cf')
 
@@ -717,6 +788,41 @@ class SearchIndex:
                 'description': row['rel_path'] if row['rel_path'] != '.' else '',
                 'drawings': [],
                 'path': row['dir_path'],
+            })
+        return results
+
+    def search_quotes(self, term: str, search_customer: bool = True) -> List[Dict]:
+        """Search quotes table; returns up to _MAX_RESULTS results ordered by mtime."""
+        escaped = _escape_like(term)
+        like = f'%{escaped}%'
+        conditions, params = [], []
+        if search_customer:
+            conditions.append("customer LIKE ? ESCAPE '\\' COLLATE NOCASE")
+            params.append(like)
+        conditions.append("quote_name LIKE ? ESCAPE '\\' COLLATE NOCASE")
+        params.append(like)
+
+        sql = (
+            f"SELECT * FROM quotes WHERE ({' OR '.join(conditions)}) "  # nosec B608  # noqa: S608
+            f"ORDER BY mtime DESC LIMIT {_MAX_RESULTS}"
+        )
+        with closing(self._connect(timeout=5.0)) as conn:
+            rows = conn.execute(sql, params).fetchall()
+
+        results = []
+        for row in rows:
+            prefix = row['prefix']
+            customer = row['customer']
+            display_customer = (
+                f"[ITAR Quote] {customer}" if prefix == 'ITAR' else f"[Quote] {customer}"
+            )
+            results.append({
+                'date': datetime.fromtimestamp(row['mtime']),
+                'customer': display_customer,
+                'job_number': row['quote_name'],
+                'description': '',
+                'drawings': [],
+                'path': row['path'],
             })
         return results
 

--- a/modules/search/module.py
+++ b/modules/search/module.py
@@ -198,6 +198,30 @@ class SearchWorker(QThread):
                     except OSError:
                         pass
 
+                # Search quotes for this customer.
+                display_quote_customer = (
+                    f"[ITAR Quote] {customer}" if prefix == 'ITAR' else f"[Quote] {customer}"
+                )
+                quotes = self.app_context.find_quote_folders(customer_path)
+                for quote_name, quote_path in quotes:
+                    if self._is_cancelled:
+                        break
+                    if not (customer_match or self.search_term in quote_name.lower()):
+                        continue
+                    try:
+                        mod_time = datetime.fromtimestamp(Path(quote_path).stat().st_mtime)
+                    except OSError:
+                        mod_time = datetime.now()
+                    self.result_found.emit({
+                        'date': mod_time,
+                        'customer': display_quote_customer,
+                        'job_number': quote_name,
+                        'description': '',
+                        'drawings': [],
+                        'path': quote_path,
+                    })
+                    self.result_count += 1
+
     def _legacy_search(self):
         """Recursive search through all directories"""
         for prefix, base_dir in self.dirs_to_search:
@@ -648,6 +672,7 @@ class SearchModule(BaseModule):
             results = self._index.search_jobs(
                 term, search_customer, search_job, search_desc, search_drawing,
             )
+            results += self._index.search_quotes(term, search_customer)
             if include_blueprints:
                 results += self._index.search_bp(term)
         except Exception as exc:
@@ -815,7 +840,7 @@ class SearchModule(BaseModule):
         if 0 <= row < len(self.search_results):
             raw_customer = self.search_results[row]['customer']
             # Strip all known prefixes to get the bare customer name
-            for prefix in ('[ITAR] ', '[ITAR-BP] ', '[BP] ', '[IR] '):
+            for prefix in ('[ITAR] ', '[ITAR-BP] ', '[BP] ', '[IR] ', '[Quote] ', '[ITAR Quote] '):
                 raw_customer = raw_customer.replace(prefix, '')
             customer = raw_customer.strip()
 
@@ -824,7 +849,7 @@ class SearchModule(BaseModule):
                 return
 
             customer_label = self.search_results[row]['customer']
-            is_itar = customer_label.startswith(('[ITAR] ', '[ITAR-BP] '))
+            is_itar = customer_label.startswith(('[ITAR] ', '[ITAR-BP] ', '[ITAR Quote] '))
             bp_dir = self.app_context.get_setting('itar_blueprints_dir' if is_itar else 'blueprints_dir', '')
             if bp_dir:
                 customer_bp = os.path.join(bp_dir, customer)
@@ -942,14 +967,14 @@ class SearchModule(BaseModule):
             return None, None
 
         raw_customer = self.search_results[row]['customer']
-        for prefix in ('[ITAR] ', '[ITAR-BP] ', '[BP] ', '[IR] '):
+        for prefix in ('[ITAR] ', '[ITAR-BP] ', '[BP] ', '[IR] ', '[Quote] ', '[ITAR Quote] '):
             raw_customer = raw_customer.replace(prefix, '')
         customer = raw_customer.strip()
         if not customer:
             return None, None
 
         customer_label = self.search_results[row]['customer']
-        is_itar = customer_label.startswith(('[ITAR] ', '[ITAR-BP] '))
+        is_itar = customer_label.startswith(('[ITAR] ', '[ITAR-BP] ', '[ITAR Quote] '))
         bp_dir = self.app_context.get_setting(
             'itar_blueprints_dir' if is_itar else 'blueprints_dir', ''
         )


### PR DESCRIPTION
## Summary
- Quotes were completely absent from search — the index only knew about jobs and blueprint files
- Added a `quotes` SQLite table (schema migration v3); the background indexer now scans `{customer}/{quote_folder_path}/` alongside job folders
- Both the fast indexed path and the filesystem fallback emit quote results tagged `[Quote]` / `[ITAR Quote]` in the Customer column
- Schema migration v3 clears `indexed_dirs(kind='cf')` to force a one-time full re-index on first launch so existing installs pick up quotes automatically
- `[Quote]` / `[ITAR Quote]` prefixes are stripped correctly in the "Open Blueprints" context menu and blueprints-path action

## Test plan
- [x] Search for a customer name that has quotes — verify `[Quote] CustomerName` rows appear alongside jobs
- [x] Search for a quote folder name directly — verify it is found
- [x] Verify ITAR quotes show as `[ITAR Quote] CustomerName`
- [x] Open a quote result folder via context menu — verifies path stored correctly
- [x] All 24 existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search now discovers, indexes, and returns quote folders alongside job documents, showing quote name, path, customer, and modification date.
  * Quote results include formatted customer labels and extracted job-number for easy identification.

* **Improvements**
  * Incremental indexing keeps quote entries in sync with configuration and re-indexing.
  * ITAR detection extended to cover quote results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->