### PR TITLE
feat: sort search results by clicking column headers

### DIFF
--- a/modules/search/module.py
+++ b/modules/search/module.py
@@ -13,6 +13,7 @@ import re
 import ctypes
 from pathlib import Path
 from datetime import datetime
+from types import MappingProxyType
 from typing import List, Dict, Any, Optional
 from PyQt6.QtWidgets import (
     QWidget, QMessageBox, QTableWidgetItem, QApplication, QMenu,
@@ -712,15 +713,22 @@ class SearchModule(BaseModule):
 
     # ==================== Sorting ====================
 
-    _SORT_KEYS = {
+    _SORT_KEYS = MappingProxyType({
         0: lambda x: x['date'],
         1: lambda x: x['customer'].lower(),
         2: lambda x: x['job_number'].lower(),
         3: lambda x: x['description'].lower(),
         4: lambda x: ', '.join(x['drawings']).lower(),
-    }
+    })
 
     def _on_header_clicked(self, column: int):
+        selected_row = self.search_table.currentRow()
+        selected_path = (
+            self.search_results[selected_row]['path']
+            if 0 <= selected_row < len(self.search_results)
+            else None
+        )
+
         if self._sort_column == column:
             self._sort_ascending = not self._sort_ascending
         else:
@@ -729,7 +737,7 @@ class SearchModule(BaseModule):
 
         order = Qt.SortOrder.AscendingOrder if self._sort_ascending else Qt.SortOrder.DescendingOrder
         self.search_table.horizontalHeader().setSortIndicator(column, order)
-        self._apply_sort()
+        self._apply_sort(selected_path=selected_path)
 
     def _apply_sort(self, selected_path=None):
         key = self._SORT_KEYS.get(self._sort_column, lambda x: x['date'])
@@ -738,16 +746,18 @@ class SearchModule(BaseModule):
 
     def _rebuild_table(self, selected_path=None):
         self.search_table.blockSignals(True)
-        self.search_table.setRowCount(0)
-        for result in self.search_results:
-            row = self.search_table.rowCount()
-            self.search_table.insertRow(row)
-            self.search_table.setItem(row, 0, QTableWidgetItem(result['date'].strftime("%Y-%m-%d %H:%M")))
-            self.search_table.setItem(row, 1, QTableWidgetItem(result['customer']))
-            self.search_table.setItem(row, 2, QTableWidgetItem(result['job_number']))
-            self.search_table.setItem(row, 3, QTableWidgetItem(result['description']))
-            self.search_table.setItem(row, 4, QTableWidgetItem(', '.join(result['drawings'])))
-        self.search_table.blockSignals(False)
+        try:
+            self.search_table.setRowCount(0)
+            for result in self.search_results:
+                row = self.search_table.rowCount()
+                self.search_table.insertRow(row)
+                self.search_table.setItem(row, 0, QTableWidgetItem(result['date'].strftime("%Y-%m-%d %H:%M")))
+                self.search_table.setItem(row, 1, QTableWidgetItem(result['customer']))
+                self.search_table.setItem(row, 2, QTableWidgetItem(result['job_number']))
+                self.search_table.setItem(row, 3, QTableWidgetItem(result['description']))
+                self.search_table.setItem(row, 4, QTableWidgetItem(', '.join(result['drawings'])))
+        finally:
+            self.search_table.blockSignals(False)
         if selected_path is not None:
             for i, result in enumerate(self.search_results):
                 if result['path'] == selected_path:

--- a/modules/search/module.py
+++ b/modules/search/module.py
@@ -377,6 +377,8 @@ class SearchModule(BaseModule):
         self._index_worker = None  # Background index builder
         self._index: Optional[SearchIndex] = None
         self._index_failures = 0  # consecutive query errors
+        self._sort_column: int = 0   # 0 = Date
+        self._sort_ascending: bool = False  # newest first
 
         # Widget references
         self.search_edit = None
@@ -513,6 +515,11 @@ class SearchModule(BaseModule):
         # Setup table properties
         self.search_table.horizontalHeader().setStretchLastSection(True)
         self.search_table.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+
+        header = self.search_table.horizontalHeader()
+        header.setSortIndicatorShown(True)
+        header.setSortIndicator(0, Qt.SortOrder.DescendingOrder)
+        header.sectionClicked.connect(self._on_header_clicked)
 
         # Setup folder tree
         self.folder_tree.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
@@ -698,12 +705,41 @@ class SearchModule(BaseModule):
         if not results:
             return False
 
-        results.sort(key=lambda x: x['date'], reverse=True)
         self.search_results = results
+        self._apply_sort()
+        self.search_status_label.setText(f"Found {len(results)} result(s)")
+        return True
 
+    # ==================== Sorting ====================
+
+    _SORT_KEYS = {
+        0: lambda x: x['date'],
+        1: lambda x: x['customer'].lower(),
+        2: lambda x: x['job_number'].lower(),
+        3: lambda x: x['description'].lower(),
+        4: lambda x: ', '.join(x['drawings']).lower(),
+    }
+
+    def _on_header_clicked(self, column: int):
+        if self._sort_column == column:
+            self._sort_ascending = not self._sort_ascending
+        else:
+            self._sort_column = column
+            self._sort_ascending = column != 0  # date defaults descending, text ascending
+
+        order = Qt.SortOrder.AscendingOrder if self._sort_ascending else Qt.SortOrder.DescendingOrder
+        self.search_table.horizontalHeader().setSortIndicator(column, order)
+        self._apply_sort()
+
+    def _apply_sort(self, selected_path=None):
+        key = self._SORT_KEYS.get(self._sort_column, lambda x: x['date'])
+        self.search_results.sort(key=key, reverse=not self._sort_ascending)
+        self._rebuild_table(selected_path)
+
+    def _rebuild_table(self, selected_path=None):
         self.search_table.blockSignals(True)
         self.search_table.setRowCount(0)
-        for result in results:
+        for result in self.search_results:
             row = self.search_table.rowCount()
             self.search_table.insertRow(row)
             self.search_table.setItem(row, 0, QTableWidgetItem(result['date'].strftime("%Y-%m-%d %H:%M")))
@@ -712,9 +748,13 @@ class SearchModule(BaseModule):
             self.search_table.setItem(row, 3, QTableWidgetItem(result['description']))
             self.search_table.setItem(row, 4, QTableWidgetItem(', '.join(result['drawings'])))
         self.search_table.blockSignals(False)
+        if selected_path is not None:
+            for i, result in enumerate(self.search_results):
+                if result['path'] == selected_path:
+                    self.search_table.selectRow(i)
+                    break
 
-        self.search_status_label.setText(f"Found {len(results)} result(s)")
-        return True
+    # ==================== Search Control ====================
 
     def cancel_search(self):
         """Cancel the running search"""
@@ -749,29 +789,7 @@ class SearchModule(BaseModule):
             else None
         )
 
-        # Sort results by date (newest first)
-        self.search_results.sort(key=lambda x: x['date'], reverse=True)
-
-        # Rebuild table with sorted results; block signals so clearing rows
-        # doesn't wipe the folder-contents panel via itemSelectionChanged
-        self.search_table.blockSignals(True)
-        self.search_table.setRowCount(0)
-        for result in self.search_results:
-            row = self.search_table.rowCount()
-            self.search_table.insertRow(row)
-            self.search_table.setItem(row, 0, QTableWidgetItem(result['date'].strftime("%Y-%m-%d %H:%M")))
-            self.search_table.setItem(row, 1, QTableWidgetItem(result['customer']))
-            self.search_table.setItem(row, 2, QTableWidgetItem(result['job_number']))
-            self.search_table.setItem(row, 3, QTableWidgetItem(result['description']))
-            self.search_table.setItem(row, 4, QTableWidgetItem(', '.join(result['drawings'])))
-        self.search_table.blockSignals(False)
-
-        # Restore the previously selected row (fires itemSelectionChanged once)
-        if selected_path is not None:
-            for i, result in enumerate(self.search_results):
-                if result['path'] == selected_path:
-                    self.search_table.selectRow(i)
-                    break
+        self._apply_sort(selected_path=selected_path)
 
         self.search_status_label.setText(f"Found {result_count} result(s)")
         self.search_progress.hide()


### PR DESCRIPTION
## Summary

- Clicking any column header in the Search results table now sorts by that column
- Clicking the same header again toggles ascending/descending order; the sort indicator arrow reflects the current direction
- Date column defaults to descending (newest first, matching prior behavior); text columns default to ascending
- Sort state persists across searches — running a new search re-applies the active sort
- Consolidated three copies of the row-building loop into `_rebuild_table`, and extracted `_apply_sort` to keep sort logic in one place

## Test plan

- [x] Run a search, click each column header and verify results re-sort correctly
- [x] Click the same header twice and verify direction toggles
- [x] Verify Date header defaults to descending (newest first) on first click
- [x] Verify sort indicator arrow matches the active sort
- [x] Run a second search while a non-default sort is active — results should reflect that sort
- [x] Verify clicking a result row still opens the folder contents panel correctly
- [x] Verify double-click to open job still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now support interactive column sorting—click any column header to sort results in ascending or descending order
  * Sort preferences are maintained throughout your search session
  * Selected items remain highlighted after applying sorts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->