### PR TITLE
fix: use Qt file dialog in settings to avoid Flatpak portal virtual paths

### DIFF
--- a/core/settings_dialog.py
+++ b/core/settings_dialog.py
@@ -294,7 +294,10 @@ class SettingsDialog(QDialog):
         main_layout.addWidget(button_box)
 
     def browse_dir(self, line_edit: QLineEdit):
-        dir_path = QFileDialog.getExistingDirectory(self, "Select Directory")
+        dir_path = QFileDialog.getExistingDirectory(
+            self, "Select Directory", "",
+            QFileDialog.Option.DontUseNativeDialog,
+        )
         if dir_path:
             line_edit.setText(dir_path)
 


### PR DESCRIPTION
## Summary

- The native file picker on Linux Flatpak returns XDG portal paths (`/run/user/1000/doc/<uuid>/`) instead of real filesystem paths, making the configured directories unusable
- `--filesystem=home` is already in the manifest so the app has access; the problem is the picker itself
- Fix: pass `DontUseNativeDialog` to `QFileDialog.getExistingDirectory` in `settings_dialog.py` so Qt uses its own file browser and returns real `/home/...` paths

## Test plan

- [ ] On Flatpak build, open Settings and browse for a directory — path should show as `/home/user/...` not `/run/user/1000/doc/...`
- [ ] On non-Flatpak (native install), directory picker still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory selection dialog behavior in settings to ensure consistent functionality across different platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->