### PR TITLE
fix: load window icon from XDG theme in Flatpak

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -232,7 +232,9 @@ jobs:
             [ -e "$item" ] && cp -r "$item" linux/flatpak/src/
           done
           pip download --only-binary :all: -d linux/flatpak/src/wheels/ -r requirements.txt
-          cp JobDocs.iconset/icon_256x256.png linux/flatpak/icon_256x256.png
+          for size in 16x16 32x32 128x128 256x256 512x512; do
+            cp JobDocs.iconset/icon_${size}.png linux/flatpak/icon_${size}.png
+          done
 
       - name: Inject version into _version.py
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,9 @@ jobs:
             [ -e "$item" ] && cp -r "$item" linux/flatpak/src/
           done
           pip download --only-binary :all: -d linux/flatpak/src/wheels/ -r requirements.txt
-          cp JobDocs.iconset/icon_256x256.png linux/flatpak/icon_256x256.png
+          for size in 16x16 32x32 128x128 256x256 512x512; do
+            cp JobDocs.iconset/icon_${size}.png linux/flatpak/icon_${size}.png
+          done
 
       - name: Inject version into _version.py
         run: |

--- a/linux/flatpak/build-local.sh
+++ b/linux/flatpak/build-local.sh
@@ -18,8 +18,10 @@ if [ -d "$REPO_ROOT/sample_files" ]; then
     cp -r "$REPO_ROOT/sample_files" "$SRC_DIR/"
 fi
 
-echo "==> Copying icon..."
-cp "$REPO_ROOT/JobDocs.iconset/icon_256x256.png" "$SCRIPT_DIR/icon_256x256.png"
+echo "==> Copying icons..."
+for size in 16x16 32x32 128x128 256x256 512x512; do
+    cp "$REPO_ROOT/JobDocs.iconset/icon_${size}.png" "$SCRIPT_DIR/icon_${size}.png"
+done
 
 echo "==> Downloading wheels (abi3 + cp312 sip for Python 3.12 runtime)..."
 pip download --only-binary :all: \

--- a/linux/flatpak/io.github.i_machine_things.JobDocs.yml
+++ b/linux/flatpak/io.github.i_machine_things.JobDocs.yml
@@ -58,6 +58,7 @@ modules:
       - install -d /app/lib/JobDocs
       - cp -r main.py core modules shared /app/lib/JobDocs/
       - sh -c '[ -d sample_files ] && cp -r sample_files /app/lib/JobDocs/ || true'
+      - install -Dm644 icon_256x256.png /app/lib/JobDocs/icon.png
       # Launcher script
       - install -d /app/bin
       - printf '#!/bin/sh\nexec python3 /app/lib/JobDocs/main.py "$@"\n' > /app/bin/JobDocs

--- a/linux/flatpak/io.github.i_machine_things.JobDocs.yml
+++ b/linux/flatpak/io.github.i_machine_things.JobDocs.yml
@@ -42,7 +42,15 @@ modules:
       - type: file
         path: io.github.i_machine_things.JobDocs.metainfo.xml
       - type: file
+        path: icon_16x16.png
+      - type: file
+        path: icon_32x32.png
+      - type: file
+        path: icon_128x128.png
+      - type: file
         path: icon_256x256.png
+      - type: file
+        path: icon_512x512.png
     build-commands:
       # Install Python dependencies from pre-downloaded wheels (no network needed)
       - pip3 install --prefix=/app --no-index --find-links wheels/ -r requirements.txt
@@ -60,6 +68,14 @@ modules:
       # AppStream metadata
       - install -Dm644 io.github.i_machine_things.JobDocs.metainfo.xml
           /app/share/metainfo/io.github.i_machine_things.JobDocs.metainfo.xml
-      # Application icon
+      # Application icons — all sizes so the WM picks the nearest without scaling
+      - install -Dm644 icon_16x16.png
+          /app/share/icons/hicolor/16x16/apps/io.github.i_machine_things.JobDocs.png
+      - install -Dm644 icon_32x32.png
+          /app/share/icons/hicolor/32x32/apps/io.github.i_machine_things.JobDocs.png
+      - install -Dm644 icon_128x128.png
+          /app/share/icons/hicolor/128x128/apps/io.github.i_machine_things.JobDocs.png
       - install -Dm644 icon_256x256.png
           /app/share/icons/hicolor/256x256/apps/io.github.i_machine_things.JobDocs.png
+      - install -Dm644 icon_512x512.png
+          /app/share/icons/hicolor/512x512/apps/io.github.i_machine_things.JobDocs.png

--- a/linux/flatpak/io.github.i_machine_things.JobDocs.yml
+++ b/linux/flatpak/io.github.i_machine_things.JobDocs.yml
@@ -58,7 +58,6 @@ modules:
       - install -d /app/lib/JobDocs
       - cp -r main.py core modules shared /app/lib/JobDocs/
       - sh -c '[ -d sample_files ] && cp -r sample_files /app/lib/JobDocs/ || true'
-      - install -Dm644 icon_256x256.png /app/lib/JobDocs/icon.png
       # Launcher script
       - install -d /app/bin
       - printf '#!/bin/sh\nexec python3 /app/lib/JobDocs/main.py "$@"\n' > /app/bin/JobDocs

--- a/main.py
+++ b/main.py
@@ -786,13 +786,13 @@ class JobDocsMainWindow(QMainWindow):
             base = Path(__file__).resolve().parent
         candidates = [
             base / 'windows' / 'icon.ico',
+            base / 'icon.png',                          # Flatpak: installed alongside main.py
             base / 'JobDocs.iconset' / 'icon_256x256.png',
         ]
         for path in candidates:
             if path.exists():
                 self.setWindowIcon(QIcon(str(path)))
                 return
-        # Flatpak / system install: icon is in the hicolor theme, not next to main.py
         theme_icon = QIcon.fromTheme("io.github.i_machine_things.JobDocs")
         if not theme_icon.isNull():
             self.setWindowIcon(theme_icon)

--- a/main.py
+++ b/main.py
@@ -791,7 +791,11 @@ class JobDocsMainWindow(QMainWindow):
         for path in candidates:
             if path.exists():
                 self.setWindowIcon(QIcon(str(path)))
-                break
+                return
+        # Flatpak / system install: icon is in the hicolor theme, not next to main.py
+        theme_icon = QIcon.fromTheme("io.github.i_machine_things.JobDocs")
+        if not theme_icon.isNull():
+            self.setWindowIcon(theme_icon)
 
     # ==================== Module Loading ====================
 

--- a/main.py
+++ b/main.py
@@ -786,13 +786,13 @@ class JobDocsMainWindow(QMainWindow):
             base = Path(__file__).resolve().parent
         candidates = [
             base / 'windows' / 'icon.ico',
-            base / 'icon.png',                          # Flatpak: installed alongside main.py
             base / 'JobDocs.iconset' / 'icon_256x256.png',
         ]
         for path in candidates:
             if path.exists():
                 self.setWindowIcon(QIcon(str(path)))
                 return
+        # Flatpak / system install: icon is in the hicolor theme, not next to main.py
         theme_icon = QIcon.fromTheme("io.github.i_machine_things.JobDocs")
         if not theme_icon.isNull():
             self.setWindowIcon(theme_icon)


### PR DESCRIPTION
## Summary

- `_set_window_icon` checked for `JobDocs.iconset/icon_256x256.png` and `windows/icon.ico` relative to `main.py`, but in the Flatpak the icon is installed to `/app/share/icons/hicolor/256x256/apps/` — not alongside `main.py`
- No candidates matched, so `setWindowIcon` was never called and the window manager showed a placeholder (yellow "W")
- Fix: after exhausting file-path candidates, fall back to `QIcon.fromTheme("io.github.i_machine_things.JobDocs")` which resolves the hicolor theme install correctly inside the Flatpak sandbox

## Test plan

- [x] Build Flatpak from PR artifacts and verify the JobDocs icon appears in the title bar and taskbar
- [x] Confirm Windows build still shows the `.ico` icon (file-path candidate still hits first)
- [x] Confirm dev run (`python main.py`) from repo root still shows the PNG icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)