### PR TITLE
fix: grant Flatpak sandbox access to /mnt for NFS shares

### DIFF
--- a/linux/flatpak/io.github.i_machine_things.JobDocs.yml
+++ b/linux/flatpak/io.github.i_machine_things.JobDocs.yml
@@ -20,6 +20,7 @@ finish-args:
   # TODO: replace with --filesystem=xdg-data/JobDocs + portal-based dir picker
   #       once core/settings_dialog.py uses QFileDialog with portal support.
   - --filesystem=home
+  - --filesystem=/mnt
   - --filesystem=host-etc:ro
   # On systemd-resolved distros (Ubuntu, Debian) /etc/resolv.conf is a symlink
   # to /run/systemd/resolve/stub-resolv.conf. Without this mount the symlink


### PR DESCRIPTION
## Summary

- The Flatpak manifest only granted `--filesystem=home`, so any directories configured under `/mnt` (e.g. NFS shares) were invisible to the sandbox
- Users with job/blueprint directories on a network share mounted at `/mnt` received "Configured directories do not exist" on every search despite the share being mounted and accessible on the host
- Fix: add `--filesystem=/mnt` to `finish-args`

## Test plan

- [x] Configure a customer files directory on an NFS share mounted under `/mnt`
- [x] Confirm search finds jobs without the "Configured directories do not exist" error
- [x] Confirm the file picker in Settings can browse `/mnt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)