### PR TITLE
feat: CLI args to pre-fill job/quote form fields on launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A modular tool for managing blueprint files and customer job directories with su
 - **Email Drag-and-Drop** - Drag emails directly onto any drop zone and attachments are extracted automatically. Supports Outlook / O365 (saves as `.msg`, requires `pywin32` on Windows), classic Outlook desktop, and Betterbird / Thunderbird on Linux (attachments extracted from the `.eml`). Image attachments (jpg, png, etc.) are skipped by default and can be toggled in Settings. Zip attachments are automatically extracted — the files inside are added directly to the file list.
 - **PDF Preview** - Drop zone file list shows a live preview of PDF files (requires `pymupdf`)
 - **Cross-Platform** - Works on Windows, macOS, and Linux
+- **CLI Pre-fill** - Launch with `--j_no`, `--desc`, `--customer` etc. to open with fields already populated — useful for integrating with external systems
 
 ## Installation
 
@@ -71,6 +72,39 @@ Run the application:
 
 ```bash
 python main.py
+```
+
+### Command-Line Pre-fill
+
+External programs can launch JobDocs with form fields pre-populated using command-line arguments. The app opens normally and the specified fields are filled in automatically.
+
+```bash
+# Pre-fill the Job tab
+python main.py --j_no 12345 --desc "flange machining" --customer "Acme Corp" --po_no PO-9876 --drawings DWG-001,DWG-002
+
+# Pre-fill the Quote tab
+python main.py --q_no Q10042 --desc "shaft assembly" --customer "Acme Corp"
+```
+
+**Available arguments:**
+
+| Argument | Tab | Field |
+|---|---|---|
+| `--customer NAME` | Job / Quote | Customer name |
+| `--j_no NUMBER` | Job | Job number |
+| `--q_no NUMBER` | Quote | Quote number |
+| `--po_no NUMBER` | Job | PO number |
+| `--desc TEXT` | Job / Quote | Description |
+| `--drawings NUMS` | Job / Quote | Drawing numbers (comma-separated) |
+
+- If `--j_no` is present, the app opens on the **Job** tab.
+- If `--q_no` is present (and no `--j_no`), the app opens on the **Quote** tab.
+- Unknown arguments are passed through to Qt (e.g. `--platform`, `--style`).
+
+**Windows installer** — pass arguments the same way via a shortcut or `ShellExecute` call:
+
+```
+JobDocs.exe --j_no 12345 --desc "flange machining"
 ```
 
 ### First Time Setup

--- a/README.md
+++ b/README.md
@@ -80,15 +80,14 @@ External programs can launch JobDocs with form fields pre-populated. The app ope
 
 **Windows (installed build):**
 
-JobDocs is not added to `PATH` by the installer. Use the full path — the default user install location is `%LOCALAPPDATA%\Programs\JobDocs\JobDocs.exe`:
+The installer adds `JobDocs.exe` to your user `PATH`, so you can call it directly:
 
 ```powershell
-# PowerShell
-& "$env:LOCALAPPDATA\Programs\JobDocs\JobDocs.exe" --j_no 12345 --desc "flange machining" --customer "Acme Corp"
-& "$env:LOCALAPPDATA\Programs\JobDocs\JobDocs.exe" --q_no Q10042 --desc "shaft assembly"
+JobDocs.exe --j_no 12345 --desc "flange machining" --customer "Acme Corp"
+JobDocs.exe --q_no Q10042 --desc "shaft assembly"
 ```
 
-External programs should use `ShellExecute` / `CreateProcess` with the full path to the exe.
+You may need to open a new terminal after installing for `PATH` to take effect. External programs can also use `ShellExecute` / `CreateProcess` with the full install path (`%LOCALAPPDATA%\Programs\JobDocs\JobDocs.exe`).
 
 **Linux (Flatpak):**
 ```bash

--- a/README.md
+++ b/README.md
@@ -76,14 +76,23 @@ python main.py
 
 ### Command-Line Pre-fill
 
-External programs can launch JobDocs with form fields pre-populated using command-line arguments. The app opens normally and the specified fields are filled in automatically.
+External programs can launch JobDocs with form fields pre-populated. The app opens normally and the specified fields are filled in automatically.
 
+**Windows (installed build):**
+```
+JobDocs.exe --j_no 12345 --desc "flange machining" --customer "Acme Corp" --po_no PO-9876
+JobDocs.exe --q_no Q10042 --desc "shaft assembly" --customer "Acme Corp"
+```
+
+**Linux (Flatpak):**
 ```bash
-# Pre-fill the Job tab
-python main.py --j_no 12345 --desc "flange machining" --customer "Acme Corp" --po_no PO-9876 --drawings DWG-001,DWG-002
+flatpak run io.github.i_machine_things.JobDocs --j_no 12345 --desc "flange machining"
+flatpak run io.github.i_machine_things.JobDocs --q_no Q10042 --desc "shaft assembly"
+```
 
-# Pre-fill the Quote tab
-python main.py --q_no Q10042 --desc "shaft assembly" --customer "Acme Corp"
+**Development (source):**
+```bash
+python main.py --j_no 12345 --desc "flange machining"
 ```
 
 **Available arguments:**
@@ -97,15 +106,8 @@ python main.py --q_no Q10042 --desc "shaft assembly" --customer "Acme Corp"
 | `--desc TEXT` | Job / Quote | Description |
 | `--drawings NUMS` | Job / Quote | Drawing numbers (comma-separated) |
 
-- If `--j_no` is present, the app opens on the **Job** tab.
-- If `--q_no` is present (and no `--j_no`), the app opens on the **Quote** tab.
-- Unknown arguments are passed through to Qt (e.g. `--platform`, `--style`).
-
-**Windows installer** — pass arguments the same way via a shortcut or `ShellExecute` call:
-
-```
-JobDocs.exe --j_no 12345 --desc "flange machining"
-```
+- If `--j_no` is present the app opens on the **Job** tab; if `--q_no` is present (and no `--j_no`) it opens on the **Quote** tab.
+- Unrecognised arguments are forwarded to Qt (e.g. `--platform`, `--style`).
 
 ### First Time Setup
 

--- a/README.md
+++ b/README.md
@@ -79,10 +79,16 @@ python main.py
 External programs can launch JobDocs with form fields pre-populated. The app opens normally and the specified fields are filled in automatically.
 
 **Windows (installed build):**
+
+JobDocs is not added to `PATH` by the installer. Use the full path — the default user install location is `%LOCALAPPDATA%\Programs\JobDocs\JobDocs.exe`:
+
+```powershell
+# PowerShell
+& "$env:LOCALAPPDATA\Programs\JobDocs\JobDocs.exe" --j_no 12345 --desc "flange machining" --customer "Acme Corp"
+& "$env:LOCALAPPDATA\Programs\JobDocs\JobDocs.exe" --q_no Q10042 --desc "shaft assembly"
 ```
-JobDocs.exe --j_no 12345 --desc "flange machining" --customer "Acme Corp" --po_no PO-9876
-JobDocs.exe --q_no Q10042 --desc "shaft assembly" --customer "Acme Corp"
-```
+
+External programs should use `ShellExecute` / `CreateProcess` with the full path to the exe.
 
 **Linux (Flatpak):**
 ```bash
@@ -90,7 +96,7 @@ flatpak run io.github.i_machine_things.JobDocs --j_no 12345 --desc "flange machi
 flatpak run io.github.i_machine_things.JobDocs --q_no Q10042 --desc "shaft assembly"
 ```
 
-**Development (source):**
+**Development (source only):**
 ```bash
 python main.py --j_no 12345 --desc "flange machining"
 ```

--- a/build_scripts/JobDocs.iss
+++ b/build_scripts/JobDocs.iss
@@ -23,14 +23,19 @@ Compression=lzma2/max
 SolidCompression=yes
 WizardStyle=modern
 PrivilegesRequired=lowest
-PrivilegesRequiredOverridesAllowed=commandline
+PrivilegesRequiredOverridesAllowed=dialog
 ChangesEnvironment=yes
 
 [Registry]
-; Add install directory to user PATH so JobDocs.exe is callable from the command line.
-; {olddata} expands to the current PATH value; NeedsAddPath guards against duplicates.
-Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; \
-  ValueData: "{olddata};{app}"; Check: NeedsAddPath(ExpandConstant('{app}'))
+; Add install directory to PATH so JobDocs.exe is callable from the command line.
+; Per-user install writes to HKCU; all-users (admin) install writes to HKLM.
+; Each entry is gated by its own check to prevent duplicates and wrong-hive writes.
+Root: HKCU; Subkey: "Environment"; \
+  ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}"; \
+  Check: NeedsAddPathUser(ExpandConstant('{app}'))
+Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; \
+  ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}"; \
+  Check: NeedsAddPathAdmin(ExpandConstant('{app}'))
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -74,35 +79,63 @@ Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChang
 var
   KeepSettings: Boolean;
 
-{ Returns True if AppDir is not already present in the user PATH. }
-function NeedsAddPath(AppDir: string): Boolean;
+const
+  SysEnvKey  = 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment';
+  UserEnvKey = 'Environment';
+
+{ True when AppDir is absent from HKCU PATH — used for per-user installs. }
+function NeedsAddPathUser(AppDir: string): Boolean;
 var
   EnvPath: string;
 begin
-  if not RegQueryStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', EnvPath) then
+  Result := False;
+  if IsAdminInstallMode then Exit;
+  if not RegQueryStringValue(HKEY_CURRENT_USER, UserEnvKey, 'Path', EnvPath) then
   begin
-    Result := True;
-    Exit;
+    Result := True; Exit;
   end;
-  Result := Pos(';' + Uppercase(AppDir) + ';',
-                ';' + Uppercase(EnvPath) + ';') = 0;
+  Result := Pos(';' + Uppercase(AppDir) + ';', ';' + Uppercase(EnvPath) + ';') = 0;
 end;
 
-{ Removes AppDir from the user PATH on uninstall. }
+{ True when AppDir is absent from HKLM PATH — used for all-users (admin) installs. }
+function NeedsAddPathAdmin(AppDir: string): Boolean;
+var
+  EnvPath: string;
+begin
+  Result := False;
+  if not IsAdminInstallMode then Exit;
+  if not RegQueryStringValue(HKEY_LOCAL_MACHINE, SysEnvKey, 'Path', EnvPath) then
+  begin
+    Result := True; Exit;
+  end;
+  Result := Pos(';' + Uppercase(AppDir) + ';', ';' + Uppercase(EnvPath) + ';') = 0;
+end;
+
+{ Removes AppDir from whichever PATH hive was used during install. }
 procedure RemoveFromPath(AppDir: string);
 var
+  RootKey: Integer;
+  SubKey: string;
   EnvPath: string;
   SearchStr: string;
   P: Integer;
 begin
-  if not RegQueryStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', EnvPath) then
-    Exit;
+  if IsAdminInstallMode then
+  begin
+    RootKey := HKEY_LOCAL_MACHINE;
+    SubKey  := SysEnvKey;
+  end else
+  begin
+    RootKey := HKEY_CURRENT_USER;
+    SubKey  := UserEnvKey;
+  end;
+  if not RegQueryStringValue(RootKey, SubKey, 'Path', EnvPath) then Exit;
   SearchStr := ';' + AppDir;
   P := Pos(LowerCase(SearchStr + ';'), LowerCase(EnvPath + ';'));
   if P > 0 then
   begin
     Delete(EnvPath, P, Length(SearchStr));
-    RegWriteExpandStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', EnvPath);
+    RegWriteExpandStringValue(RootKey, SubKey, 'Path', EnvPath);
   end;
 end;
 
@@ -118,16 +151,16 @@ end;
 
 procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
 var
-  ConfigDir: String;
+  ConfigDir: string;
 begin
   if CurUninstallStep = usPostUninstall then
   begin
+    RemoveFromPath(ExpandConstant('{app}'));
     if not KeepSettings then
     begin
       ConfigDir := ExpandConstant('{localappdata}\JobDocs');
       if DirExists(ConfigDir) then
         DelTree(ConfigDir, True, True, True);
     end;
-    RemoveFromPath(ExpandConstant('{app}'));
   end;
 end;

--- a/build_scripts/JobDocs.iss
+++ b/build_scripts/JobDocs.iss
@@ -24,6 +24,13 @@ SolidCompression=yes
 WizardStyle=modern
 PrivilegesRequired=lowest
 PrivilegesRequiredOverridesAllowed=commandline
+ChangesEnvironment=yes
+
+[Registry]
+; Add install directory to user PATH so JobDocs.exe is callable from the command line.
+; {olddata} expands to the current PATH value; NeedsAddPath guards against duplicates.
+Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; \
+  ValueData: "{olddata};{app}"; Check: NeedsAddPath(ExpandConstant('{app}'))
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -67,6 +74,38 @@ Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChang
 var
   KeepSettings: Boolean;
 
+{ Returns True if AppDir is not already present in the user PATH. }
+function NeedsAddPath(AppDir: string): Boolean;
+var
+  EnvPath: string;
+begin
+  if not RegQueryStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', EnvPath) then
+  begin
+    Result := True;
+    Exit;
+  end;
+  Result := Pos(';' + Uppercase(AppDir) + ';',
+                ';' + Uppercase(EnvPath) + ';') = 0;
+end;
+
+{ Removes AppDir from the user PATH on uninstall. }
+procedure RemoveFromPath(AppDir: string);
+var
+  EnvPath: string;
+  SearchStr: string;
+  P: Integer;
+begin
+  if not RegQueryStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', EnvPath) then
+    Exit;
+  SearchStr := ';' + AppDir;
+  P := Pos(LowerCase(SearchStr + ';'), LowerCase(EnvPath + ';'));
+  if P > 0 then
+  begin
+    Delete(EnvPath, P, Length(SearchStr));
+    RegWriteExpandStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', EnvPath);
+  end;
+end;
+
 function InitializeUninstall(): Boolean;
 begin
   KeepSettings := MsgBox(
@@ -89,5 +128,6 @@ begin
       if DirExists(ConfigDir) then
         DelTree(ConfigDir, True, True, True);
     end;
+    RemoveFromPath(ExpandConstant('{app}'));
   end;
 end;

--- a/core/base_module.py
+++ b/core/base_module.py
@@ -161,6 +161,18 @@ class BaseModule(ABC):
         if self._app_context:
             self._app_context.show_info(title, message)
 
+    def prefill_fields(self, data: dict) -> None:
+        """Prefill form fields from CLI launch arguments.
+
+        Keys understood by built-in modules:
+          customer, j_no, po_no, desc, drawings (Job tab)
+          customer, q_no, desc, drawings        (Quote tab)
+
+        Override in modules that have a form to prefill; the default is a no-op
+        so existing modules that don't override are unaffected.
+        """
+        pass
+
     def _check_po_rfq_files(self, newly_added: List[str], files_store: List[str], list_widget) -> None:
         """Scan newly-added files for PO/RFQ signals and prompt the user for each flagged file.
 

--- a/launcher/launcher.c
+++ b/launcher/launcher.c
@@ -36,10 +36,29 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR lpCmd, int nShow)
     _snwprintf_s(script, MAX_PATH, _TRUNCATE,
                  L"%s\\app\\main.py", exe_path);
 
-    /* CreateProcess wants a mutable command-line buffer. */
-    wchar_t cmdline[MAX_PATH * 2];
-    _snwprintf_s(cmdline, MAX_PATH * 2, _TRUNCATE,
-                 L"\"%s\" \"%s\"", python, script);
+    /* Forward any args the user passed to JobDocs.exe by recovering them from
+     * the original wide-char command line.  GetCommandLineW() returns the full
+     * command line including the exe name, so skip past that first token. */
+    const wchar_t *cli = GetCommandLineW();
+    if (*cli == L'"') {
+        cli++;                              /* skip opening quote  */
+        while (*cli && *cli != L'"') cli++; /* skip exe path       */
+        if (*cli) cli++;                    /* skip closing quote  */
+    } else {
+        while (*cli && *cli != L' ') cli++; /* skip unquoted name  */
+    }
+    while (*cli == L' ') cli++;             /* skip whitespace     */
+
+    /* CreateProcess wants a mutable command-line buffer.
+     * 32 767 is the practical maximum for CreateProcessW. */
+    wchar_t cmdline[32767];
+    if (*cli) {
+        _snwprintf_s(cmdline, 32767, _TRUNCATE,
+                     L"\"%s\" \"%s\" %s", python, script, cli);
+    } else {
+        _snwprintf_s(cmdline, 32767, _TRUNCATE,
+                     L"\"%s\" \"%s\"", python, script);
+    }
 
     STARTUPINFOW si;
     ZeroMemory(&si, sizeof(si));

--- a/main.py
+++ b/main.py
@@ -310,9 +310,11 @@ class _UpdateDialog(QDialog):
 
 
 def _parse_prefill_args(argv: list) -> tuple:
-    """Extract JobDocs prefill args from argv; return (prefill_dict, remaining_argv_for_qt).
+    """Extract JobDocs prefill args from argv.
 
-    Unknown args are left in remaining so Qt can consume platform/style flags.
+    Returns (prefill_dict, remaining_argv_for_qt). Known flags (--customer,
+    --j_no, --q_no, --po_no, --desc, --drawings) are consumed; unrecognised
+    args are left in remaining so Qt can consume platform/style flags.
     """
     parser = argparse.ArgumentParser(prog='JobDocs', add_help=False)
     parser.add_argument('--customer', metavar='NAME')
@@ -1371,7 +1373,12 @@ near-instant even across thousands of jobs.</p>""",
     # ==================== CLI Prefill ====================
 
     def _apply_prefill(self, data: Dict[str, str]) -> None:
-        """Prefill module form fields from CLI args and switch to the relevant tab."""
+        """Prefill module form fields from CLI args and switch to the relevant tab.
+
+        Iterates loaded modules and calls prefill_fields(data) on each. Then
+        switches the active tab to Job (if j_no is present) or Quote (if q_no
+        is present). Called once from __init__ when prefill data is supplied.
+        """
         for module in self.modules:
             module.prefill_fields(data)
 

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ JobDocs - Modular Blueprint and Job Management System
 Main application entry point using the modular plugin architecture.
 """
 
+import argparse
 import io
 import logging
 import os
@@ -306,6 +307,25 @@ class _UpdateDialog(QDialog):
             self._app_context.set_setting('updates_skipped_version', self._latest_version)
             self._app_context.save_settings()
         self.reject()
+
+
+def _parse_prefill_args(argv: list) -> tuple:
+    """Extract JobDocs prefill args from argv; return (prefill_dict, remaining_argv_for_qt).
+
+    Unknown args are left in remaining so Qt can consume platform/style flags.
+    """
+    parser = argparse.ArgumentParser(prog='JobDocs', add_help=False)
+    parser.add_argument('--customer', metavar='NAME')
+    parser.add_argument('--j_no', metavar='NUMBER')
+    parser.add_argument('--q_no', metavar='NUMBER')
+    parser.add_argument('--po_no', metavar='NUMBER')
+    parser.add_argument('--desc', metavar='TEXT')
+    parser.add_argument('--drawings', metavar='NUMS',
+                        help='Comma-separated drawing numbers')
+    known, remaining = parser.parse_known_args(argv)
+
+    prefill = {k: v for k, v in vars(known).items() if v is not None}
+    return prefill, remaining
 
 
 def _flatpak_dns_fix() -> None:
@@ -610,7 +630,7 @@ class JobDocsMainWindow(QMainWindow):
         'skip_image_attachments': True,
     }
 
-    def __init__(self):
+    def __init__(self, prefill: Dict[str, str] | None = None):
         super().__init__()
 
         # Configuration
@@ -678,6 +698,9 @@ class JobDocsMainWindow(QMainWindow):
             self.tabs.setCurrentIndex(default_tab)
 
         self.statusBar().showMessage("Ready")  # pyright: ignore[reportOptionalMemberAccess]
+
+        if prefill:
+            self._apply_prefill(prefill)
 
     # ==================== Settings & History ====================
 
@@ -1345,6 +1368,25 @@ near-instant even across thousands of jobs.</p>""",
             from shared.widgets import DropZone
             DropZone.set_skip_image_attachments(self.settings.get('skip_image_attachments', True))
 
+    # ==================== CLI Prefill ====================
+
+    def _apply_prefill(self, data: Dict[str, str]) -> None:
+        """Prefill module form fields from CLI args and switch to the relevant tab."""
+        for module in self.modules:
+            module.prefill_fields(data)
+
+        if 'j_no' in data:
+            target_tab = 'Job'
+        elif 'q_no' in data:
+            target_tab = 'Quote'
+        else:
+            return
+
+        for i in range(self.tabs.count()):
+            if self.tabs.tabText(i) == target_tab:
+                self.tabs.setCurrentIndex(i)
+                break
+
     # ==================== UI Helpers ====================
 
     def apply_ui_style(self):
@@ -1461,7 +1503,8 @@ def main():
     except Exception:
         pass
 
-    app = QApplication(sys.argv)
+    prefill, qt_argv = _parse_prefill_args(sys.argv[1:])
+    app = QApplication([sys.argv[0]] + qt_argv)
     app.setApplicationName("JobDocs")
     app.setOrganizationName("JobDocs")
 
@@ -1473,7 +1516,7 @@ def main():
     print("=" * 60)
     print()
 
-    window = JobDocsMainWindow()
+    window = JobDocsMainWindow(prefill=prefill if prefill else None)
     window.show()
 
     def _on_update_available(tag: str, url: str, asset_url: str) -> None:

--- a/modules/job/module.py
+++ b/modules/job/module.py
@@ -1006,6 +1006,7 @@ class JobModule(BaseModule):
         dialog.exec()
 
     def prefill_fields(self, data: dict) -> None:
+        """Prefill Create New form fields from CLI launch arguments."""
         if 'customer' in data and self.customer_combo is not None:
             self.customer_combo.setCurrentText(data['customer'])
         if 'j_no' in data and self.job_number_edit is not None:

--- a/modules/job/module.py
+++ b/modules/job/module.py
@@ -1005,6 +1005,18 @@ class JobModule(BaseModule):
         dialog = BulkCreateDialog(self.app_context, self._widget)
         dialog.exec()
 
+    def prefill_fields(self, data: dict) -> None:
+        if 'customer' in data and self.customer_combo is not None:
+            self.customer_combo.setCurrentText(data['customer'])
+        if 'j_no' in data and self.job_number_edit is not None:
+            self.job_number_edit.setText(data['j_no'])
+        if 'po_no' in data and self.po_number_edit is not None:
+            self.po_number_edit.setText(data['po_no'])
+        if 'desc' in data and self.description_edit is not None:
+            self.description_edit.setText(data['desc'])
+        if 'drawings' in data and self.drawings_edit is not None:
+            self.drawings_edit.setText(data['drawings'])
+
     def cleanup(self):
         """Cleanup resources"""
         # Stop any running worker thread

--- a/modules/quote/module.py
+++ b/modules/quote/module.py
@@ -960,6 +960,7 @@ class QuoteModule(BaseModule):
         dialog.exec()
 
     def prefill_fields(self, data: dict) -> None:
+        """Prefill Create New form fields from CLI launch arguments."""
         if 'customer' in data and self.quote_customer_combo is not None:
             self.quote_customer_combo.setCurrentText(data['customer'])
         if 'q_no' in data and self.quote_number_edit is not None:

--- a/modules/quote/module.py
+++ b/modules/quote/module.py
@@ -959,6 +959,16 @@ class QuoteModule(BaseModule):
         dialog = BulkCreateDialog(self.app_context, self._widget)
         dialog.exec()
 
+    def prefill_fields(self, data: dict) -> None:
+        if 'customer' in data and self.quote_customer_combo is not None:
+            self.quote_customer_combo.setCurrentText(data['customer'])
+        if 'q_no' in data and self.quote_number_edit is not None:
+            self.quote_number_edit.setText(data['q_no'])
+        if 'desc' in data and self.quote_description_edit is not None:
+            self.quote_description_edit.setText(data['desc'])
+        if 'drawings' in data and self.quote_drawings_edit is not None:
+            self.quote_drawings_edit.setText(data['drawings'])
+
     def cleanup(self):
         """Cleanup resources"""
         # Stop any running worker thread


### PR DESCRIPTION
## Summary

- Adds `_parse_prefill_args()` in `main.py` using `argparse`; unknown args pass through to Qt unchanged
- `JobDocsMainWindow.__init__` accepts an optional `prefill` dict and calls `_apply_prefill()` after modules load
- `BaseModule.prefill_fields(data)` added as a no-op default; `JobModule` and `QuoteModule` override it to set their form fields
- App auto-switches to the Job tab when `--j_no` is supplied, Quote tab when `--q_no` is supplied
- README updated with usage table and Windows installer example

**Supported args:**

| Arg | Tab | Field |
|---|---|---|
| `--customer NAME` | Job / Quote | Customer name |
| `--j_no NUMBER` | Job | Job number |
| `--q_no NUMBER` | Quote | Quote number |
| `--po_no NUMBER` | Job | PO number |
| `--desc TEXT` | Job / Quote | Description |
| `--drawings NUMS` | Job / Quote | Drawing numbers (comma-separated) |

## Test plan

- [x] `python main.py --j_no 12345 --desc "flange" --customer "Acme"` — opens on Job tab with fields filled
- [x] `python main.py --q_no Q10042 --desc "shaft"` — opens on Quote tab with fields filled
- [x] `python main.py` (no args) — normal startup, no change in behaviour
- [x] `python main.py --style Fusion` (Qt arg) — still applies style correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-line pre-fill support, letting the app start with selected form fields already filled in.
  * The app now opens the matching tab automatically when job or quote number values are provided.
  * Job and Quote forms can now be pre-populated with customer, numbers, description, and drawings details.
* **Documentation**
  * Updated the README with usage examples, supported command-line options, and Windows launch notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->