### PR TITLE
feat: add PO Line and Revision fields to Job tab

### DIFF
--- a/.claude/S&P.md
+++ b/.claude/S&P.md
@@ -2389,3 +2389,21 @@ Actionable: 1  Nitpicks: 0
    - If a custom `doubleClicked` slot also calls `setExpanded(not isExpanded())`, the two toggles cancel out
    - Fix: call `self.folder_tree.setExpandsOnDoubleClick(False)` at widget construction time
    - Use `self.folder_tree.itemFromIndex(index)` in the slot (not `currentItem()`) to get the exact clicked item
+
+
+---
+
+## 2026-06-30 — `modules/job/module.py`, `modules/job/ui/job_tab.ui` (PO Line and Revision fields — PR #282)
+
+**Review:** CodeRabbit flagged two issues on the initial review.
+**Result:** Both resolved before merge.
+
+### Findings
+
+1. **New prefill fields must be wired into the job creation flow, not just the form**
+   - `po_line` and `revision` were set on the form via `prefill_fields` but not read from the widgets in `create_job()`/`create_single_job()`, so submitted jobs silently dropped them.
+   - Fix: read `po_line_edit.text()` and `revision_edit.text()` in `create_job()`; pass both through to `create_single_job()` and include in the job data dict.
+
+2. **QGroupBox max-height cap can clip new rows — use a zero-height spacer instead of removing the cap**
+   - `jobInfoGroup` had a 200 px max-height; adding PO Line and Revision rows risked clipping the bottom row.
+   - Fix: kept the 200 px cap (sufficient for 6 rows at 3 px spacing); added a `Qt::Vertical` spacer with `sizeHint height=0` at the last grid row to pin rows to the top without spreading them, preventing clip without removing the constraint.

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ JobDocs-Windows/
 ignore.me.md
 sample file structure
 tools/gen_test_data.py
+
+test_cli*.py
+test_cli*.bas

--- a/README.md
+++ b/README.md
@@ -137,8 +137,10 @@ python main.py --j_no 12345 --desc "flange machining"
 | `--j_no NUMBER` | Job | Job number |
 | `--q_no NUMBER` | Quote | Quote number |
 | `--po_no NUMBER` | Job | PO number |
+| `--po_line LINE` | Job | PO line |
 | `--desc TEXT` | Job / Quote | Description |
 | `--drawings NUMS` | Job / Quote | Drawing numbers (comma-separated) |
+| `--revision REV` | Job | Revision |
 
 - If `--j_no` is present the app opens on the **Job** tab; if `--q_no` is present (and no `--j_no`) it opens on the **Quote** tab.
 - Unrecognised arguments are forwarded to Qt (e.g. `--platform`, `--style`).

--- a/README.md
+++ b/README.md
@@ -145,6 +145,56 @@ python main.py --j_no 12345 --desc "flange machining"
 - If `--j_no` is present the app opens on the **Job** tab; if `--q_no` is present (and no `--j_no`) it opens on the **Quote** tab.
 - Unrecognised arguments are forwarded to Qt (e.g. `--platform`, `--style`).
 
+#### Integration examples
+
+**Python**
+
+```python
+import subprocess
+import os
+
+exe = os.path.expandvars(r"%LOCALAPPDATA%\Programs\JobDocs\JobDocs.exe")
+
+# Open Job tab with all fields pre-filled
+subprocess.Popen([
+    exe,
+    "--customer", "Acme Corp",
+    "--j_no",     "12345",
+    "--po_no",    "PO-9876",
+    "--po_line",  "1",
+    "--desc",     "flange machining",
+    "--drawings", "DWG-001,DWG-002",
+    "--revision", "A",
+])
+```
+
+**VBA (Excel / Access / JobBOSS)**
+
+```vba
+Sub OpenInJobDocs()
+    Dim wsh As Object
+    Dim exePath As String
+
+    Set wsh = CreateObject("WScript.Shell")
+    exePath = wsh.ExpandEnvironmentStrings("%LOCALAPPDATA%\Programs\JobDocs\JobDocs.exe")
+
+    ' Pull values from the current JobBOSS Job Entry record
+    wsh.Run """" & exePath & """" & _
+             " --customer """ & Forms!Jobs!Customer_ID    & """" & _
+             " --j_no """     & Forms!Jobs!Job_Number     & """" & _
+             " --po_no """    & Forms!Jobs!Cust_PO        & """" & _
+             " --po_line """  & Forms!Jobs!PO_Line        & """" & _
+             " --desc """     & Forms!Jobs!Description    & """" & _
+             " --revision """ & Forms!Jobs!Revision       & """", _
+             1, False
+
+    Set wsh = Nothing
+End Sub
+```
+
+Both callers launch JobDocs as a non-blocking GUI process and return immediately.
+For an all-users install replace `%LOCALAPPDATA%\Programs` with `%ProgramFiles%`.
+
 ### Creating Quotes
 
 1. Go to the **Quote** tab → **Create New**

--- a/main.py
+++ b/main.py
@@ -321,9 +321,11 @@ def _parse_prefill_args(argv: list) -> tuple:
     parser.add_argument('--j_no', metavar='NUMBER')
     parser.add_argument('--q_no', metavar='NUMBER')
     parser.add_argument('--po_no', metavar='NUMBER')
+    parser.add_argument('--po_line', metavar='LINE')
     parser.add_argument('--desc', metavar='TEXT')
     parser.add_argument('--drawings', metavar='NUMS',
                         help='Comma-separated drawing numbers')
+    parser.add_argument('--revision', metavar='REV')
     known, remaining = parser.parse_known_args(argv)
 
     prefill = {k: v for k, v in vars(known).items() if v is not None}

--- a/modules/bulk/module.py
+++ b/modules/bulk/module.py
@@ -271,8 +271,10 @@ class BulkCreateDialog(QDialog):
                 skipped += 1
             else:
                 if job_module.create_single_job(
-                    customer, job['job_number'], job['po_number'],
-                    job['description'], job['drawings'], is_itar, []
+                    customer, job['job_number'],
+                    job.get('po_number', ''), job.get('po_line', ''),
+                    job['description'], job['drawings'],
+                    job.get('revision', ''), is_itar, []
                 ):
                     created += 1
 

--- a/modules/job/module.py
+++ b/modules/job/module.py
@@ -103,6 +103,8 @@ class JobModule(BaseModule):
         self.customer_combo = None
         self.job_number_edit = None
         self.po_number_edit = None
+        self.po_line_edit = None
+        self.revision_edit = None
         self.job_status_label = None
         self.description_edit = None
         self.drawings_edit = None
@@ -157,9 +159,11 @@ class JobModule(BaseModule):
         self.customer_combo = widget.customer_combo
         self.job_number_edit = widget.job_number_edit
         self.po_number_edit = widget.po_number_edit
+        self.po_line_edit = widget.po_line_edit
         self.job_status_label = widget.job_status_label
         self.description_edit = widget.description_edit
         self.drawings_edit = widget.drawings_edit
+        self.revision_edit = widget.revision_edit
         self.itar_check = widget.itar_check
         self.job_files_list = widget.job_files_list
         self.job_files_list.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
@@ -524,8 +528,10 @@ class JobModule(BaseModule):
         self.customer_combo.setCurrentText("")
         self.job_number_edit.clear()
         self.po_number_edit.clear()
+        self.po_line_edit.clear()
         self.description_edit.clear()
         self.drawings_edit.clear()
+        self.revision_edit.clear()
         self.itar_check.setChecked(False)
         self.job_files.clear()
         self.job_files_list.clear()
@@ -1013,10 +1019,14 @@ class JobModule(BaseModule):
             self.job_number_edit.setText(data['j_no'])
         if 'po_no' in data and self.po_number_edit is not None:
             self.po_number_edit.setText(data['po_no'])
+        if 'po_line' in data and self.po_line_edit is not None:
+            self.po_line_edit.setText(data['po_line'])
         if 'desc' in data and self.description_edit is not None:
             self.description_edit.setText(data['desc'])
         if 'drawings' in data and self.drawings_edit is not None:
             self.drawings_edit.setText(data['drawings'])
+        if 'revision' in data and self.revision_edit is not None:
+            self.revision_edit.setText(data['revision'])
 
     def cleanup(self):
         """Cleanup resources"""

--- a/modules/job/module.py
+++ b/modules/job/module.py
@@ -387,7 +387,9 @@ class JobModule(BaseModule):
 
         created = 0
         for job_num in job_numbers:
-            if self.create_single_job(customer, job_num, po_number, po_line, description, drawings, revision, is_itar, all_files):
+            if self.create_single_job(
+                    customer, job_num, po_number, po_line,
+                    description, drawings, revision, is_itar, all_files):
                 created += 1
 
         if created > 0:

--- a/modules/job/module.py
+++ b/modules/job/module.py
@@ -338,8 +338,10 @@ class JobModule(BaseModule):
         customer = self.customer_combo.currentText().strip()
         job_input = self.job_number_edit.text().strip()
         po_number = self.po_number_edit.text().strip()
+        po_line = self.po_line_edit.text().strip()
         description = self.description_edit.text().strip()
         drawings_str = self.drawings_edit.text().strip()
+        revision = self.revision_edit.text().strip()
         is_itar = self.itar_check.isChecked()
 
         if not all([customer, job_input, description]):
@@ -385,7 +387,7 @@ class JobModule(BaseModule):
 
         created = 0
         for job_num in job_numbers:
-            if self.create_single_job(customer, job_num, po_number, description, drawings, is_itar, all_files):
+            if self.create_single_job(customer, job_num, po_number, po_line, description, drawings, revision, is_itar, all_files):
                 created += 1
 
         if created > 0:
@@ -402,8 +404,9 @@ class JobModule(BaseModule):
             self.show_error("Error", "Failed to create jobs")
 
     def create_single_job(
-            self, customer: str, job_number: str, po_number: str, description: str,
-            drawings: List[str], is_itar: bool, files: List[str]) -> bool:
+            self, customer: str, job_number: str, po_number: str, po_line: str,
+            description: str, drawings: List[str], revision: str,
+            is_itar: bool, files: List[str]) -> bool:
         """Create a single job folder"""
         try:
             bp_dir, cf_dir = self.app_context.get_directories(is_itar)
@@ -476,8 +479,10 @@ class JobModule(BaseModule):
                 'customer': customer,
                 'job_number': job_number,
                 'po_number': po_number,
+                'po_line': po_line,
                 'description': description,
                 'drawings': drawings,
+                'revision': revision,
                 'path': str(job_path)
             })
             self.app_context.save_history()

--- a/modules/job/ui/job_tab.ui
+++ b/modules/job/ui/job_tab.ui
@@ -154,30 +154,58 @@
            </widget>
           </item>
           <item row="3" column="0">
+           <widget class="QLabel" name="poLineLabel">
+            <property name="text">
+             <string>PO Line:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLineEdit" name="po_line_edit">
+            <property name="placeholderText">
+             <string>PO Line (Optional)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
            <widget class="QLabel" name="descriptionLabel">
             <property name="text">
              <string>Description:</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item row="4" column="1">
            <widget class="QLineEdit" name="description_edit"/>
           </item>
-          <item row="4" column="0">
+          <item row="5" column="0">
            <widget class="QLabel" name="drawingsLabel">
             <property name="text">
              <string>Drawings:</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="5" column="1">
            <widget class="QLineEdit" name="drawings_edit">
             <property name="placeholderText">
              <string>comma-separated</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
+          <item row="6" column="0">
+           <widget class="QLabel" name="revisionLabel">
+            <property name="text">
+             <string>Revision:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QLineEdit" name="revision_edit">
+            <property name="placeholderText">
+             <string>Revision (Optional)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
            <widget class="QCheckBox" name="itar_check">
             <property name="text">
              <string>ITAR Job (uses separate directories)</string>

--- a/modules/job/ui/job_tab.ui
+++ b/modules/job/ui/job_tab.ui
@@ -147,65 +147,79 @@
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QLineEdit" name="po_number_edit">
-            <property name="placeholderText">
-             <string>Customer PO Number (Optional)</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="poRowLayout">
+            <item>
+             <widget class="QLineEdit" name="po_number_edit">
+              <property name="placeholderText">
+               <string>Customer PO Number (Optional)</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="poLineLabel">
+              <property name="text">
+               <string>PO Line:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="po_line_edit">
+              <property name="placeholderText">
+               <string>Line</string>
+              </property>
+              <property name="maximumWidth">
+               <number>60</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item row="3" column="0">
-           <widget class="QLabel" name="poLineLabel">
-            <property name="text">
-             <string>PO Line:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QLineEdit" name="po_line_edit">
-            <property name="placeholderText">
-             <string>PO Line (Optional)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
            <widget class="QLabel" name="descriptionLabel">
             <property name="text">
              <string>Description:</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="3" column="1">
            <widget class="QLineEdit" name="description_edit"/>
           </item>
-          <item row="5" column="0">
+          <item row="4" column="0">
            <widget class="QLabel" name="drawingsLabel">
             <property name="text">
              <string>Drawings:</string>
             </property>
            </widget>
           </item>
+          <item row="4" column="1">
+           <layout class="QHBoxLayout" name="drawingsRowLayout">
+            <item>
+             <widget class="QLineEdit" name="drawings_edit">
+              <property name="placeholderText">
+               <string>comma-separated</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="revisionLabel">
+              <property name="text">
+               <string>Rev.:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="revision_edit">
+              <property name="placeholderText">
+               <string>Rev</string>
+              </property>
+              <property name="maximumWidth">
+               <number>60</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
           <item row="5" column="1">
-           <widget class="QLineEdit" name="drawings_edit">
-            <property name="placeholderText">
-             <string>comma-separated</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="revisionLabel">
-            <property name="text">
-             <string>Revision:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="1">
-           <widget class="QLineEdit" name="revision_edit">
-            <property name="placeholderText">
-             <string>Revision (Optional)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="1">
            <widget class="QCheckBox" name="itar_check">
             <property name="text">
              <string>ITAR Job (uses separate directories)</string>

--- a/modules/job/ui/job_tab.ui
+++ b/modules/job/ui/job_tab.ui
@@ -53,6 +53,12 @@
        </property>
        <item>
         <widget class="QGroupBox" name="jobInfoGroup">
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>200</height>
+          </size>
+         </property>
          <property name="title">
           <string>Job Information</string>
          </property>

--- a/modules/job/ui/job_tab.ui
+++ b/modules/job/ui/job_tab.ui
@@ -226,6 +226,19 @@
             </property>
            </widget>
           </item>
+          <item row="6" column="0" colspan="2">
+           <spacer name="jobInfoSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>0</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
          </layout>
         </widget>
        </item>

--- a/modules/job/ui/job_tab.ui
+++ b/modules/job/ui/job_tab.ui
@@ -53,12 +53,6 @@
        </property>
        <item>
         <widget class="QGroupBox" name="jobInfoGroup">
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>200</height>
-          </size>
-         </property>
          <property name="title">
           <string>Job Information</string>
          </property>


### PR DESCRIPTION
## Summary

- Adds **PO Line** and **Revision** input fields to the Job → Create New form, positioned after PO # and after Drawings respectively
- Both fields are optional, cleared by Clear button, and pre-filled by `prefill_fields`
- CLI args `--po_line` and `--revision` added so external callers (e.g. JobBOSS VBA macro) can pass these on launch
- README args table updated

## Test plan

- [x] PO Line and Revision fields appear on the Job → Create New tab
- [x] Clear button clears both fields
- [x] `JobDocs.exe --j_no 123 --po_line 1 --revision A` pre-fills all fields correctly
- [x] Existing fields (customer, job #, PO #, description, drawings) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional **PO Line** and **Revision** inputs to the Job tab.
  * These values can now be provided via command-line prefill and are carried through job creation (including bulk creation).
* **Bug Fixes**
  * Ensured the new fields are cleared/reset correctly when the Job form is cleared.
* **Documentation**
  * Updated the command-line prefill reference and examples to include the new Job tab arguments (`--po_line`, `--revision`).
* **Chores**
  * Updated ignore rules for additional CLI test artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->