### PR TITLE
feat: default blueprints search checkbox to checked

### DIFF
--- a/modules/search/ui/search_tab.ui
+++ b/modules/search/ui/search_tab.ui
@@ -267,7 +267,7 @@
             <string>Blueprints directories</string>
            </property>
            <property name="checked">
-            <bool>false</bool>
+            <bool>true</bool>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
## Summary
- Sets `search_blueprints_check` to checked by default in the search tab UI

## Test plan
- [ ] Open Search tab — "Blueprints directories" checkbox should be checked on first load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default selection for “Blueprints directories” in the search options, so it now starts enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->